### PR TITLE
Add safe alternative to query_row

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 homepage = "https://github.com/jgallagher/rusqlite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 homepage = "https://github.com/jgallagher/rusqlite"

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -42,7 +42,7 @@ pub const SQLITE_NULL : c_int = 5;
 pub type SqliteDestructor = extern "C" fn(*mut c_void);
 
 pub fn SQLITE_TRANSIENT() -> SqliteDestructor {
-    unsafe { mem::transmute(-1i) }
+    unsafe { mem::transmute(-1is) }
 }
 
 pub fn code_to_str(code: c_int) -> &'static str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 //! }
 //! ```
 #![feature(unsafe_destructor)]
+#![allow(unstable)]
 
 extern crate libc;
 
@@ -210,7 +211,7 @@ impl SqliteConnection {
     ///     }
     /// }
     /// ```
-    pub fn execute(&self, sql: &str, params: &[&ToSql]) -> SqliteResult<uint> {
+    pub fn execute(&self, sql: &str, params: &[&ToSql]) -> SqliteResult<usize> {
         self.prepare(sql).and_then(|mut stmt| stmt.execute(params))
     }
 
@@ -280,7 +281,7 @@ impl SqliteConnection {
         self.db.borrow_mut().decode_result(code)
     }
 
-    fn changes(&self) -> uint {
+    fn changes(&self) -> usize {
         self.db.borrow_mut().changes()
     }
 }
@@ -390,8 +391,8 @@ impl InnerSqliteConnection {
         })
     }
 
-    fn changes(&mut self) -> uint {
-        unsafe{ ffi::sqlite3_changes(self.db) as uint }
+    fn changes(&mut self) -> usize {
+        unsafe{ ffi::sqlite3_changes(self.db) as usize }
     }
 }
 
@@ -432,7 +433,7 @@ impl<'conn> SqliteStatement<'conn> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn execute(&mut self, params: &[&ToSql]) -> SqliteResult<uint> {
+    pub fn execute(&mut self, params: &[&ToSql]) -> SqliteResult<usize> {
         self.reset_if_needed();
 
         unsafe {
@@ -796,7 +797,7 @@ mod test {
         assert_eq!(db.last_insert_rowid(), 1);
 
         let mut stmt = db.prepare("INSERT INTO foo DEFAULT VALUES").unwrap();
-        for _ in range(0i, 9) {
+        for _ in range(0i32, 9) {
             stmt.execute(&[]).unwrap();
         }
         assert_eq!(db.last_insert_rowid(), 10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!                   )", &[]).unwrap();
 //!     let me = Person {
 //!         id: 0,
-//!         name: "Steven".to_string(),
+//!         name: format!("Steven"),
 //!         time_created: time::get_time(),
 //!         data: None
 //!     };
@@ -43,7 +43,7 @@
 //!             time_created: row.get(2),
 //!             data: row.get(3)
 //!         };
-//!         println!("Found person {}", person);
+//!         println!("Found person {:?}", person);
 //!     }
 //! }
 //! ```
@@ -206,7 +206,7 @@ impl SqliteConnection {
     /// fn update_rows(conn: &SqliteConnection) {
     ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?", &[&1i32]) {
     ///         Ok(updated) => println!("{} rows were updated", updated),
-    ///         Err(err) => println!("update failed: {}", err),
+    ///         Err(err) => println!("update failed: {:?}", err),
     ///     }
     /// }
     /// ```
@@ -511,7 +511,7 @@ impl<'conn> SqliteStatement<'conn> {
 
 impl<'conn> fmt::Show for SqliteStatement<'conn> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Statement( conn: {}, stmt: {} )", self.conn, self.stmt)
+        write!(f, "Statement( conn: {:?}, stmt: {:?} )", self.conn, self.stmt)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -138,7 +138,7 @@ impl<T: ToSql> ToSql for Option<T> {
 /// ```rust,no_run
 /// # use rusqlite::{SqliteConnection, SqliteResult};
 /// # use rusqlite::types::{Null};
-/// fn insert_null(conn: &SqliteConnection) -> SqliteResult<uint> {
+/// fn insert_null(conn: &SqliteConnection) -> SqliteResult<usize> {
 ///     conn.execute("INSERT INTO people (name) VALUES (?)", &[&Null])
 /// }
 /// ```
@@ -186,7 +186,7 @@ impl FromSql for Vec<u8> {
         let c_blob = ffi::sqlite3_column_blob(stmt, col);
         let len = ffi::sqlite3_column_bytes(stmt, col);
 
-        assert!(len >= 0); let len = len as uint;
+        assert!(len >= 0); let len = len as usize;
 
         Ok(Vec::from_raw_buf(mem::transmute(c_blob), len))
     }


### PR DESCRIPTION
`query_row_safe` is functionally identical to `query_row`, but returns an `SqliteError` when it fails instead of panicking. This pull request also contains the changes contained in my other pull request, so that it will compile properly.