### PR TITLE
Rust 1.0.0 alpha changes, add `query_row_safe`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+rusqlite contributors (sorted alphabetically)
+=============================================
+
+* [John Gallagher](https://github.com/jgallagher)
+* [Marcus Klaas de Vries](https://github.com/marcusklaas)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 homepage = "https://github.com/jgallagher/rusqlite"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Version 0.0.6 (2014-01-10)
+
+* Updates to track latest rustc changes (1.0.0-alpha).
+* Add `query_row_safe`, a `SqliteResult`-returning variant of `query_row`.
+
 # Version 0.0.5 (2014-01-07)
 
 * Updates to track latest rustc changes (closure syntax).

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -42,7 +42,7 @@ pub const SQLITE_NULL : c_int = 5;
 pub type SqliteDestructor = extern "C" fn(*mut c_void);
 
 pub fn SQLITE_TRANSIENT() -> SqliteDestructor {
-    unsafe { mem::transmute(-1i) }
+    unsafe { mem::transmute(-1is) }
 }
 
 pub fn code_to_str(code: c_int) -> &'static str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //! an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).
 //!
 //! ```rust
+//! #![allow(unstable)]
 //! extern crate rusqlite;
 //! extern crate time;
 //!
@@ -48,6 +49,7 @@
 //! }
 //! ```
 #![feature(unsafe_destructor)]
+#![allow(unstable)]
 
 extern crate libc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!             time_created: row.get(2),
 //!             data: row.get(3)
 //!         };
-//!         println!("Found person {}", person);
+//!         println!("Found person {:?}", person);
 //!     }
 //! }
 //! ```
@@ -511,7 +511,7 @@ impl<'conn> SqliteStatement<'conn> {
 
 impl<'conn> fmt::Show for SqliteStatement<'conn> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Statement( conn: {}, stmt: {} )", self.conn, self.stmt)
+        write!(f, "Statement( conn: {:?}, stmt: {:?} )", self.conn, self.stmt)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl SqliteConnection {
     ///     }
     /// }
     /// ```
-    pub fn execute(&self, sql: &str, params: &[&ToSql]) -> SqliteResult<uint> {
+    pub fn execute(&self, sql: &str, params: &[&ToSql]) -> SqliteResult<c_int> {
         self.prepare(sql).and_then(|mut stmt| stmt.execute(params))
     }
 
@@ -280,7 +280,7 @@ impl SqliteConnection {
         self.db.borrow_mut().decode_result(code)
     }
 
-    fn changes(&self) -> uint {
+    fn changes(&self) -> c_int {
         self.db.borrow_mut().changes()
     }
 }
@@ -390,8 +390,8 @@ impl InnerSqliteConnection {
         })
     }
 
-    fn changes(&mut self) -> uint {
-        unsafe{ ffi::sqlite3_changes(self.db) as uint }
+    fn changes(&mut self) -> c_int {
+        unsafe{ ffi::sqlite3_changes(self.db) }
     }
 }
 
@@ -432,7 +432,7 @@ impl<'conn> SqliteStatement<'conn> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn execute(&mut self, params: &[&ToSql]) -> SqliteResult<uint> {
+    pub fn execute(&mut self, params: &[&ToSql]) -> SqliteResult<c_int> {
         self.reset_if_needed();
 
         unsafe {
@@ -796,7 +796,7 @@ mod test {
         assert_eq!(db.last_insert_rowid(), 1);
 
         let mut stmt = db.prepare("INSERT INTO foo DEFAULT VALUES").unwrap();
-        for _ in range(0i, 9) {
+        for _ in range(0i32, 9) {
             stmt.execute(&[]).unwrap();
         }
         assert_eq!(db.last_insert_rowid(), 10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,12 @@ pub struct SqliteError {
     pub message: String,
 }
 
+impl fmt::String for SqliteError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "SqliteError( code: {}, message: {} )", self.code, self.message)
+    }
+}
+
 impl SqliteError {
     fn from_handle(db: *mut ffi::Struct_sqlite3, code: c_int) -> SqliteError {
         let message = if db.is_null() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,9 +136,15 @@ impl<T: ToSql> ToSql for Option<T> {
 /// ## Example
 ///
 /// ```rust,no_run
+/// #![allow(unstable)]
+/// # extern crate libc;
+/// # extern crate rusqlite;
 /// # use rusqlite::{SqliteConnection, SqliteResult};
 /// # use rusqlite::types::{Null};
-/// fn insert_null(conn: &SqliteConnection) -> SqliteResult<uint> {
+/// # use libc::{c_int};
+/// fn main() {
+/// }
+/// fn insert_null(conn: &SqliteConnection) -> SqliteResult<c_int> {
 ///     conn.execute("INSERT INTO people (name) VALUES (?)", &[&Null])
 /// }
 /// ```
@@ -186,7 +192,7 @@ impl FromSql for Vec<u8> {
         let c_blob = ffi::sqlite3_column_blob(stmt, col);
         let len = ffi::sqlite3_column_bytes(stmt, col);
 
-        assert!(len >= 0); let len = len as uint;
+        assert!(len >= 0); let len = len as usize;
 
         Ok(Vec::from_raw_buf(mem::transmute(c_blob), len))
     }


### PR DESCRIPTION
This should encompass both #9 and #10