### PR TITLE
Rustup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 homepage = "https://github.com/jgallagher/rusqlite"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub struct SqliteError {
     pub message: String,
 }
 
-impl fmt::String for SqliteError {
+impl fmt::Display for SqliteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "SqliteError( code: {}, message: {} )", self.code, self.message)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ impl SqliteConnection {
     }
 }
 
-impl fmt::Show for SqliteConnection {
+impl fmt::Debug for SqliteConnection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SqliteConnection()")
     }
@@ -550,7 +550,7 @@ impl<'conn> SqliteStatement<'conn> {
     }
 }
 
-impl<'conn> fmt::Show for SqliteStatement<'conn> {
+impl<'conn> fmt::Debug for SqliteStatement<'conn> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Statement( conn: {:?}, stmt: {:?} )", self.conn, self.stmt)
     }


### PR DESCRIPTION
`unwrap_err` had to be replaced by explicit matches because the unit type `()` does not implement `Display`, which is required in order to use `unwrap_err`. This is not very natural (requiring `Debug` makes more sense) and likely to be reverted soon, or so I've been told. Until then, these changes will make rusqlite compile on nightly rustc again.