### PR TITLE
Make `query_row` a synonym for `query_row_safe`.

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -181,7 +181,7 @@ mod test {
         }
         {
             let _tx = db.transaction().unwrap();
-            assert_eq!(2i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)));
+            assert_eq!(2i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
         }
     }
 
@@ -200,7 +200,7 @@ mod test {
         }
         {
             let _tx = db.transaction().unwrap();
-            assert_eq!(2i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)));
+            assert_eq!(2i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
         }
     }
 
@@ -228,6 +228,6 @@ mod test {
                 }
             }
         }
-        assert_eq!(3i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)));
+        assert_eq!(3i32, db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -246,7 +246,7 @@ mod test {
         let v1234 = vec![1u8,2,3,4];
         db.execute("INSERT INTO foo(b) VALUES (?)", &[&v1234]).unwrap();
 
-        let v: Vec<u8> = db.query_row("SELECT b FROM foo", &[], |r| r.get(0));
+        let v: Vec<u8> = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(v, v1234);
     }
 
@@ -257,7 +257,7 @@ mod test {
         let s = "hello, world!";
         db.execute("INSERT INTO foo(t) VALUES (?)", &[&s.to_string()]).unwrap();
 
-        let from: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0));
+        let from: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(from, s);
     }
 
@@ -268,7 +268,7 @@ mod test {
         let ts = time::Timespec{sec: 10_000, nsec: 0 };
         db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts]).unwrap();
 
-        let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0));
+        let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(from, ts);
     }
 


### PR DESCRIPTION
This is a breaking change for anyone using `query_row`. To update code
that used the old `query_row`, you must now `.unwrap()` the returned
result.