### PR TITLE
Avoid the RFC1214 warning on nightly.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -75,7 +75,8 @@ pub trait ToSql {
 
 /// A trait for types that can be created from a SQLite value.
 pub trait FromSql {
-    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> SqliteResult<Self>;
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> SqliteResult<Self>
+        where Self: Sized;
 
     /// FromSql types can implement this method and use sqlite3_column_type to check that
     /// the type reported by SQLite matches a type suitable for Self. This method is used


### PR DESCRIPTION
The compiler was tightened up a little to check things more rigorously,
which caused some new errors to be generated (the errors are being
phased in as warnings at the moment, but it doesn't hurt to fix it
pre-emptively).