### PR TITLE
libsqlite3-sys: build on Mac OS X by linking to system library

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -1,5 +1,14 @@
 extern crate pkg_config;
 
+use std::env;
+
 fn main() {
-    pkg_config::find_library("sqlite3").unwrap();
+    let target = env::var("TARGET").unwrap();
+
+    if target.contains("darwin") {
+        println!("cargo:rustc-link-lib=sqlite3");
+        println!("cargo:rustc-link-search=/usr/lib");
+    } else {
+        pkg_config::find_library("sqlite3").unwrap();
+    }
 }


### PR DESCRIPTION
This change will let libsqlite3-sys (and hence rusqlite) compile on Mac OS X using the system sqlite3 installation.