### PR TITLE
Update libc version to ~0.2 and fix mod test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ load_extension = ["libsqlite3-sys/load_extension"]
 [dependencies]
 time = "~0.1.0"
 bitflags = "~0.1"
-libc = "~0.1"
+libc = "~0.2"
 
 [dev-dependencies]
 tempdir = "~0.3.4"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -15,4 +15,4 @@ load_extension = []
 pkg-config = "~0.3"
 
 [dependencies]
-libc = "~0.1"
+libc = "~0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,7 +980,6 @@ impl<'stmt> SqliteRow<'stmt> {
 
 #[cfg(test)]
 mod test {
-    extern crate libsqlite3_sys as ffi;
     extern crate tempdir;
     pub use super::*;
     use self::tempdir::TempDir;
@@ -1234,7 +1233,6 @@ mod test {
     }
 
     mod query_and_then_tests {
-        extern crate libsqlite3_sys as ffi;
         use super::*;
 
         #[derive(Debug, PartialEq)]


### PR DESCRIPTION
I've only changed version in Cargo.tomls, because libc 0.1 had incorrect signedness of char on ARM and the crate didn't compile. I've also removed redundant `extern crate`s from mod test, because `cargo test` failed to compile for me. I hope new libc don't break anything, but I've tested only on ARM, so YMMV.