### PR TITLE
Add support for named parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Version UPCOMING (TBD)
 
 * Adds `backup` feature that exposes SQLite's online backup API.
+* Adds a variety of `..._named` methods for executing queries using named placeholder parameters.
 
 # Version 0.5.0 (2015-12-08)
 

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -88,7 +88,7 @@ impl<'conn> SqliteStatement<'conn> {
     /// Will return `Err` if binding parameters fails, the executed statement returns rows (in
     /// which case `query` should be used instead), or the underling SQLite call fails.
     pub fn execute_named(&mut self, params: &[(&str, &ToSql)]) -> SqliteResult<c_int> {
-        try!(self.bind_named_parameters(params));
+        try!(self.bind_parameters_named(params));
         unsafe {
             self.execute_()
         }
@@ -118,13 +118,13 @@ impl<'conn> SqliteStatement<'conn> {
                            params: &[(&str, &ToSql)])
                            -> SqliteResult<SqliteRows<'a>> {
         self.reset_if_needed();
-        try!(self.bind_named_parameters(params));
+        try!(self.bind_parameters_named(params));
 
         self.needs_reset = true;
         Ok(SqliteRows::new(self))
     }
 
-    fn bind_named_parameters(&mut self, params: &[(&str, &ToSql)]) -> SqliteResult<()> {
+    fn bind_parameters_named(&mut self, params: &[(&str, &ToSql)]) -> SqliteResult<()> {
         // Always check that the number of parameters is correct.
         assert!(params.len() as c_int == unsafe { ffi::sqlite3_bind_parameter_count(self.stmt) },
                 "incorrect number of parameters to query(): expected {}, got {}",

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -10,12 +10,15 @@ use types::ToSql;
 impl SqliteConnection {
     /// Convenience method to prepare and execute a single SQL statement with named parameter(s).
     ///
+    /// On success, returns the number of rows that were changed or inserted or deleted (via
+    /// `sqlite3_changes`).
+    ///
     /// ## Example
     ///
     /// ```rust,no_run
     /// # use rusqlite::{SqliteConnection, SqliteResult};
     /// fn insert(conn: &SqliteConnection) -> SqliteResult<i32> {
-    ///   conn.execute_named("INSERT INTO test (id, name, flag) VALUES (:id, :name, :flag)", &[(":name", &"one")])
+    ///     conn.execute_named("INSERT INTO test (name) VALUES (:name)", &[(":name", &"one")])
     /// }
     /// ```
     ///
@@ -27,7 +30,8 @@ impl SqliteConnection {
         self.prepare(sql).and_then(|mut stmt| stmt.execute_named(params))
     }
 
-    /// Convenience method to execute a query with named parameter(s) that is expected to return a single row.
+    /// Convenience method to execute a query with named parameter(s) that is expected to return
+    /// a single row.
     ///
     /// If the query returns more than one row, all rows except the first are ignored.
     ///
@@ -75,7 +79,7 @@ impl<'conn> SqliteStatement<'conn> {
     ///
     /// # Failure
     ///
-    /// Return None if `name` is invalid (NulError) or if no matching parameter is found.
+    /// Return None if `name` is invalid or if no matching parameter is found.
     pub fn parameter_index(&self, name: &str) -> Option<i32> {
         unsafe {
             CString::new(name).ok().and_then(|c_name| {
@@ -98,8 +102,8 @@ impl<'conn> SqliteStatement<'conn> {
     /// ```rust,no_run
     /// # use rusqlite::{SqliteConnection, SqliteResult};
     /// fn insert(conn: &SqliteConnection) -> SqliteResult<i32> {
-    ///   let mut stmt = try!(conn.prepare("INSERT INTO test (id, name, flag) VALUES (:id, :name, :flag)"));
-    ///   return stmt.execute_named(&[(":name", &"one")]);
+    ///     let mut stmt = try!(conn.prepare("INSERT INTO test (name) VALUES (:name)"));
+    ///     stmt.execute_named(&[(":name", &"one")])
     /// }
     /// ```
     ///
@@ -114,19 +118,20 @@ impl<'conn> SqliteStatement<'conn> {
         }
     }
 
-    /// Execute the prepared statement with named parameter(s), returning an iterator over the resulting rows.
+    /// Execute the prepared statement with named parameter(s), returning an iterator over the
+    /// resulting rows.
     ///
     /// ## Example
     ///
     /// ```rust,no_run
     /// # use rusqlite::{SqliteConnection, SqliteResult, SqliteRows};
     /// fn query(conn: &SqliteConnection) -> SqliteResult<()> {
-    ///   let mut stmt = try!(conn.prepare("SELECT * FROM test where name = :name"));
-    ///   let mut rows = try!(stmt.query_named(&[(":name", &"one")]));
-    ///   for row in rows {
-    ///   // ...
-    ///   }
-    ///   return Ok(())
+    ///     let mut stmt = try!(conn.prepare("SELECT * FROM test where name = :name"));
+    ///     let mut rows = try!(stmt.query_named(&[(":name", &"one")]));
+    ///     for row in rows {
+    ///         // ...
+    ///     }
+    ///     Ok(())
     /// }
     /// ```
     ///

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -48,15 +48,7 @@ impl SqliteConnection {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query_named(params));
 
-        match rows.next() {
-            Some(row) => row.map(f),
-            None => {
-                Err(SqliteError {
-                    code: ffi::SQLITE_NOTICE,
-                    message: "Query did not return a row".to_string(),
-                })
-            }
-        }
+        rows.get_expected_row().map(f)
     }
 }
 

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -1,4 +1,3 @@
-// use std::collections::HashMap;
 use std::ffi::CString;
 use libc::c_int;
 
@@ -62,19 +61,6 @@ impl SqliteConnection {
 }
 
 impl<'conn> SqliteStatement<'conn> {
-    // pub fn parameter_names(&self) -> HashMap<String, i32> {
-    // let n = unsafe { ffi::sqlite3_bind_parameter_count(self.stmt) };
-    // let mut index_by_name = HashMap::with_capacity(n as usize);
-    // for i in 1..n+1 {
-    // let c_name = unsafe { ffi::sqlite3_bind_parameter_name(self.stmt, i) };
-    // if !c_name.is_null() {
-    // let c_slice = unsafe { CStr::from_ptr(c_name).to_bytes() };
-    // index_by_name.insert(str::from_utf8(c_slice).unwrap().to_string(), n);
-    // }
-    // }
-    // index_by_name
-    // }
-
     /// Return the index of an SQL parameter given its name.
     ///
     /// # Failure

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -189,6 +189,12 @@ mod test {
         let mut stmt = db.prepare("INSERT INTO test (id, name, flag) VALUES (:id, :name, :flag)")
                          .unwrap();
         stmt.execute_named(&[(":name", &"one")]).unwrap();
+
+        assert_eq!(1i32,
+                   db.query_named_row("SELECT COUNT(*) FROM test WHERE name = :name",
+                                      &[(":name", &"one")],
+                                      |r| r.get(0))
+                     .unwrap());
     }
 
     #[test]

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -1,4 +1,4 @@
-//use std::collections::HashMap;
+// use std::collections::HashMap;
 use std::ffi::CString;
 use libc::c_int;
 
@@ -35,34 +35,41 @@ impl SqliteConnection {
     ///
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
-    pub fn query_named_row<T, F>(&self, sql: &str, params: &[(&str, &ToSql)], f: F) -> SqliteResult<T>
-                           where F: FnOnce(SqliteRow) -> T {
+    pub fn query_named_row<T, F>(&self,
+                                 sql: &str,
+                                 params: &[(&str, &ToSql)],
+                                 f: F)
+                                 -> SqliteResult<T>
+        where F: FnOnce(SqliteRow) -> T
+    {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query_named(params));
 
         match rows.next() {
             Some(row) => row.map(f),
-            None      => Err(SqliteError{
-                code: ffi::SQLITE_NOTICE,
-                message: "Query did not return a row".to_string(),
-            })
+            None => {
+                Err(SqliteError {
+                    code: ffi::SQLITE_NOTICE,
+                    message: "Query did not return a row".to_string(),
+                })
+            }
         }
     }
 }
 
 impl<'conn> SqliteStatement<'conn> {
-    /*pub fn parameter_names(&self) -> HashMap<String, i32> {
-        let n = unsafe { ffi::sqlite3_bind_parameter_count(self.stmt) };
-        let mut index_by_name = HashMap::with_capacity(n as usize);
-        for i in 1..n+1 {
-            let c_name = unsafe { ffi::sqlite3_bind_parameter_name(self.stmt, i) };
-            if !c_name.is_null() {
-                let c_slice = unsafe { CStr::from_ptr(c_name).to_bytes() };
-                index_by_name.insert(str::from_utf8(c_slice).unwrap().to_string(), n);
-            }
-        }
-        index_by_name
-    }*/
+    // pub fn parameter_names(&self) -> HashMap<String, i32> {
+    // let n = unsafe { ffi::sqlite3_bind_parameter_count(self.stmt) };
+    // let mut index_by_name = HashMap::with_capacity(n as usize);
+    // for i in 1..n+1 {
+    // let c_name = unsafe { ffi::sqlite3_bind_parameter_name(self.stmt, i) };
+    // if !c_name.is_null() {
+    // let c_slice = unsafe { CStr::from_ptr(c_name).to_bytes() };
+    // index_by_name.insert(str::from_utf8(c_slice).unwrap().to_string(), n);
+    // }
+    // }
+    // index_by_name
+    // }
 
     /// Return the index of an SQL parameter given its name.
     ///
@@ -71,12 +78,12 @@ impl<'conn> SqliteStatement<'conn> {
     /// Return None if `name` is invalid (NulError) or if no matching parameter is found.
     pub fn parameter_index(&self, name: &str) -> Option<i32> {
         unsafe {
-            CString::new(name).ok().and_then(|c_name|
+            CString::new(name).ok().and_then(|c_name| {
                 match ffi::sqlite3_bind_parameter_index(self.stmt, c_name.as_ptr()) {
                     0 => None, // A zero is returned if no matching parameter is found.
-                    n => Some(n)
+                    n => Some(n),
                 }
-            )
+            })
 
         }
     }
@@ -126,7 +133,9 @@ impl<'conn> SqliteStatement<'conn> {
     /// # Failure
     ///
     /// Will return `Err` if binding parameters fails.
-    pub fn query_named<'a>(&'a mut self, params: &[(&str, &ToSql)]) -> SqliteResult<SqliteRows<'a>> {
+    pub fn query_named<'a>(&'a mut self,
+                           params: &[(&str, &ToSql)])
+                           -> SqliteResult<SqliteRows<'a>> {
         self.reset_if_needed();
 
         unsafe {
@@ -139,9 +148,9 @@ impl<'conn> SqliteStatement<'conn> {
 
     unsafe fn bind_named_parameters(&mut self, params: &[(&str, &ToSql)]) -> SqliteResult<()> {
         for &(name, value) in params {
-            let i = try!(self.parameter_index(name).ok_or(SqliteError{
+            let i = try!(self.parameter_index(name).ok_or(SqliteError {
                 code: ffi::SQLITE_MISUSE,
-                message: format!("Invalid parameter name: {}", name)
+                message: format!("Invalid parameter name: {}", name),
             }));
             try!(self.conn.decode_result(value.bind_parameter(self.stmt, i)));
         }
@@ -158,26 +167,35 @@ mod test {
         let db = SqliteConnection::open_in_memory().unwrap();
         db.execute_batch("CREATE TABLE foo(x INTEGER)").unwrap();
 
-        assert_eq!(db.execute_named("INSERT INTO foo(x) VALUES (:x)", &[(":x", &1i32)]).unwrap(), 1);
-        assert_eq!(db.execute_named("INSERT INTO foo(x) VALUES (:x)", &[(":x", &2i32)]).unwrap(), 1);
+        assert_eq!(db.execute_named("INSERT INTO foo(x) VALUES (:x)", &[(":x", &1i32)]).unwrap(),
+                   1);
+        assert_eq!(db.execute_named("INSERT INTO foo(x) VALUES (:x)", &[(":x", &2i32)]).unwrap(),
+                   1);
 
-        assert_eq!(3i32, db.query_named_row("SELECT SUM(x) FROM foo WHERE x > :x", &[(":x", &0i32)], |r| r.get(0)).unwrap());
+        assert_eq!(3i32,
+                   db.query_named_row("SELECT SUM(x) FROM foo WHERE x > :x",
+                                      &[(":x", &0i32)],
+                                      |r| r.get(0))
+                     .unwrap());
     }
 
-   #[test]
+    #[test]
     fn test_stmt_execute_named() {
         let db = SqliteConnection::open_in_memory().unwrap();
-        let sql = "CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag INTEGER)";
+        let sql = "CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag \
+                   INTEGER)";
         db.execute_batch(sql).unwrap();
 
-        let mut stmt = db.prepare("INSERT INTO test (id, name, flag) VALUES (:id, :name, :flag)").unwrap();
+        let mut stmt = db.prepare("INSERT INTO test (id, name, flag) VALUES (:id, :name, :flag)")
+                         .unwrap();
         stmt.execute_named(&[(":name", &"one")]).unwrap();
     }
 
-   #[test]
+    #[test]
     fn test_query_named() {
         let db = SqliteConnection::open_in_memory().unwrap();
-        let sql = "CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag INTEGER)";
+        let sql = "CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag \
+                   INTEGER)";
         db.execute_batch(sql).unwrap();
 
         let mut stmt = db.prepare("SELECT * FROM test where name = :name").unwrap();

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -38,7 +38,7 @@ impl SqliteConnection {
     ///
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
-    pub fn query_named_row<T, F>(&self,
+    pub fn query_row_named<T, F>(&self,
                                  sql: &str,
                                  params: &[(&str, &ToSql)],
                                  f: F)
@@ -183,7 +183,7 @@ mod test {
                    1);
 
         assert_eq!(3i32,
-                   db.query_named_row("SELECT SUM(x) FROM foo WHERE x > :x",
+                   db.query_row_named("SELECT SUM(x) FROM foo WHERE x > :x",
                                       &[(":x", &0i32)],
                                       |r| r.get(0))
                      .unwrap());
@@ -200,7 +200,7 @@ mod test {
         stmt.execute_named(&[(":name", &"one")]).unwrap();
 
         assert_eq!(1i32,
-                   db.query_named_row("SELECT COUNT(*) FROM test WHERE name = :name",
+                   db.query_row_named("SELECT COUNT(*) FROM test WHERE name = :name",
                                       &[(":name", &"one")],
                                       |r| r.get(0))
                      .unwrap());


### PR DESCRIPTION
Builds on #63.

@gwenn do you want to look this over? I made several small changes; the bigger ones are:

* Added assertions to check that we actually bind all the expected parameters. This is tricky and I'm not totally happy with what I came up with - I'm always `assert!()`-ing that the _number_ of parameters matches, and an extra sanity check is to `debug_assert!()` that all the names are unique.
* Renamed `query_named_row` -> `query_row_named`; I think that's slightly more consistent with things like `iter` / `iter_mut`.