### PR TITLE
Simplify execute_batch implementation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,13 +658,12 @@ impl InnerConnection {
     fn execute_batch(&mut self, sql: &str) -> Result<()> {
         let c_sql = try!(str_to_cstring(sql));
         unsafe {
-            let mut errmsg: *mut c_char = mem::uninitialized();
             let r = ffi::sqlite3_exec(self.db(),
             c_sql.as_ptr(),
             None,
             ptr::null_mut(),
-            &mut errmsg);
-            self.decode_result_with_errmsg(r, errmsg)
+            ptr::null_mut());
+            self.decode_result(r)
         }
     }
 


### PR DESCRIPTION
There is no difference between calling `sqlite3_errmsg` or using the last parameter of `sqlite3_exec`:
```c
      memcpy(*pzErrMsg, sqlite3_errmsg(db), nErrMsg);
```