### PR TITLE
Add feature for BLOB I/O.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "rusqlite"
 [features]
 load_extension = ["libsqlite3-sys/load_extension"]
 backup = []
+blob = []
 functions = []
 trace = []
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
   The old, prefixed names are still exported but are deprecated.
 * Adds a variety of `..._named` methods for executing queries using named placeholder parameters.
 * Adds `backup` feature that exposes SQLite's online backup API.
+* Adds `blob` feature that exposes SQLite's Incremental I/O for BLOB API.
 * Adds `functions` feature that allows user-defined scalar functions to be added to
   open `SqliteConnection`s.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ features](http://doc.crates.io/manifest.html#the-features-section). They are:
   allows you to load Rust closures into SQLite connections for use in queries.
 * [`trace`](http://jgallagher.github.io/rusqlite/rusqlite/trace/index.html)
   allows hooks into SQLite's tracing and profiling APIs.
+* [`blob`](http://jgallagher.github.io/rusqlite/rusqlite/blob/index.html)
+  gives `std::io::{Read, Write, Seek}` access to SQL BLOBs.
 
 ### Design of Rows and Row
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -171,7 +171,8 @@ impl<'conn> io::Read for Blob<'conn> {
 
 impl<'conn> io::Write for Blob<'conn> {
     /// Write data into a BLOB incrementally. Will return `Ok(0)` if the end of the blob
-    /// has been reached.
+    /// has been reached; consider using `Write::write_all(buf)` if you want to get an
+    /// error if the entirety of the buffer cannot be written.
     ///
     /// This function may only modify the contents of the BLOB; it is not possible to increase
     /// the size of a BLOB using this API.

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -99,10 +99,11 @@ impl<'conn> io::Read for Blob<'conn> {
     /// Will return `Err` if `buf` length > i32 max value or if the underlying SQLite read call fails.
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.len() > ::std::i32::MAX as usize {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, Error {
-                code: ffi::SQLITE_TOOBIG,
-                message: "buffer too long".to_string(),
-            }));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput,
+                                      Error {
+                                          code: ffi::SQLITE_TOOBIG,
+                                          message: "buffer too long".to_string(),
+                                      }));
         }
         let mut n = buf.len() as i32;
         let size = self.size();
@@ -115,10 +116,13 @@ impl<'conn> io::Read for Blob<'conn> {
         let rc = unsafe {
             ffi::sqlite3_blob_read(self.blob, mem::transmute(buf.as_ptr()), n, self.pos)
         };
-        self.conn.decode_result(rc).map(|_| {
-            self.pos += n;
-            n as usize
-        }).map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+        self.conn
+            .decode_result(rc)
+            .map(|_| {
+                self.pos += n;
+                n as usize
+            })
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
     }
 }
 
@@ -133,18 +137,23 @@ impl<'conn> io::Write for Blob<'conn> {
     /// or if the underlying SQLite write call fails.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if buf.len() > ::std::i32::MAX as usize {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, Error {
-                code: ffi::SQLITE_TOOBIG,
-                message: "buffer too long".to_string(),
-            }));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput,
+                                      Error {
+                                          code: ffi::SQLITE_TOOBIG,
+                                          message: "buffer too long".to_string(),
+                                      }));
         }
         let n = buf.len() as i32;
         let size = self.size();
         if self.pos + n > size {
-            return Err(io::Error::new(io::ErrorKind::Other, Error {
-                code: ffi::SQLITE_MISUSE,
-                message: format!("pos = {} + n = {} > size = {}", self.pos, n, size),
-            }));
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      Error {
+                                          code: ffi::SQLITE_MISUSE,
+                                          message: format!("pos = {} + n = {} > size = {}",
+                                                           self.pos,
+                                                           n,
+                                                           size),
+                                      }));
         }
         if n <= 0 {
             return Ok(0);
@@ -152,10 +161,13 @@ impl<'conn> io::Write for Blob<'conn> {
         let rc = unsafe {
             ffi::sqlite3_blob_write(self.blob, mem::transmute(buf.as_ptr()), n, self.pos)
         };
-        self.conn.decode_result(rc).map(|_| {
-            self.pos += n;
-            n as usize
-        }).map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+        self.conn
+            .decode_result(rc)
+            .map(|_| {
+                self.pos += n;
+                n as usize
+            })
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -173,9 +185,11 @@ impl<'conn> io::Seek for Blob<'conn> {
         };
 
         if pos < 0 {
-            Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid seek to negative position"))
+            Err(io::Error::new(io::ErrorKind::InvalidInput,
+                               "invalid seek to negative position"))
         } else if pos > ::std::i32::MAX as i64 {
-            Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid seek to position > i32::MAX"))
+            Err(io::Error::new(io::ErrorKind::InvalidInput,
+                               "invalid seek to position > i32::MAX"))
         } else {
             self.pos = pos as i32;
             Ok(pos as u64)

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,0 +1,213 @@
+//! incremental BLOB I/O
+use std::mem;
+use std::ptr;
+
+use super::ffi;
+use {Error, Result, Connection};
+
+/// Handle to an open BLOB
+pub struct Blob<'conn> {
+    conn: &'conn Connection,
+    blob: *mut ffi::sqlite3_blob,
+    pos: i32,
+}
+
+/// Enumeration of possible methods to seek within an BLOB.
+pub enum SeekFrom {
+    Start(i32),
+    End(i32),
+    Current(i32),
+}
+
+impl Connection {
+    /// Open a handle to the BLOB located in `row`, `column`, `table` in database `db` ('main', 'temp', ...)
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `db`/`table`/`column` cannot be converted to a C-compatible string or if the
+    /// underlying SQLite BLOB open call fails.
+    pub fn blob_open<'a>(&'a self,
+                         db: &str,
+                         table: &str,
+                         column: &str,
+                         row: i64,
+                         read_only: bool)
+                         -> Result<Blob<'a>> {
+        let mut c = self.db.borrow_mut();
+        let mut blob = ptr::null_mut();
+        let db = try!(super::str_to_cstring(db));
+        let table = try!(super::str_to_cstring(table));
+        let column = try!(super::str_to_cstring(column));
+        let rc = unsafe {
+            ffi::sqlite3_blob_open(c.db(),
+                                   db.as_ptr(),
+                                   table.as_ptr(),
+                                   column.as_ptr(),
+                                   row,
+                                   if read_only {
+                                       0
+                                   } else {
+                                       1
+                                   },
+                                   &mut blob)
+        };
+        c.decode_result(rc).map(|_| {
+            Blob {
+                conn: self,
+                blob: blob,
+                pos: 0,
+            }
+        })
+    }
+}
+
+impl<'conn> Blob<'conn> {
+    /// Move a BLOB handle to a new row
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the underlying SQLite BLOB reopen call fails.
+    pub fn reopen(&mut self, row: i64) -> Result<()> {
+        let rc = unsafe { ffi::sqlite3_blob_reopen(self.blob, row) };
+        if rc != ffi::SQLITE_OK {
+            return self.conn.decode_result(rc);
+        }
+        self.pos = 0;
+        Ok(())
+    }
+
+    /// Return the size in bytes of the BLOB
+    pub fn size(&self) -> i32 {
+        unsafe { ffi::sqlite3_blob_bytes(self.blob) }
+    }
+
+    /// Read data from a BLOB incrementally
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `buf` length > i32 max value or if the underlying SQLite read call fails.
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<i32> {
+        if buf.len() > ::std::i32::MAX as usize {
+            return Err(Error {
+                code: ffi::SQLITE_TOOBIG,
+                message: "buffer too long".to_string(),
+            });
+        }
+        let mut n = buf.len() as i32;
+        let size = self.size();
+        if self.pos + n > size {
+            n = size - self.pos;
+        }
+        if n <= 0 {
+            return Ok(0);
+        }
+        let rc = unsafe {
+            ffi::sqlite3_blob_read(self.blob, mem::transmute(buf.as_ptr()), n, self.pos)
+        };
+        self.conn.decode_result(rc).map(|_| {
+            self.pos += n;
+            n
+        })
+    }
+
+    /// Write data into a BLOB incrementally
+    ///
+    /// This function may only modify the contents of the BLOB; it is not possible to increase the size of a BLOB using this API.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `buf` length > i32 max value or if `buf` length + offset > BLOB size
+    /// or if the underlying SQLite write call fails.
+    pub fn write(&mut self, buf: &[u8]) -> Result<i32> {
+        if buf.len() > ::std::i32::MAX as usize {
+            return Err(Error {
+                code: ffi::SQLITE_TOOBIG,
+                message: "buffer too long".to_string(),
+            });
+        }
+        let n = buf.len() as i32;
+        let size = self.size();
+        if self.pos + n > size {
+            return Err(Error {
+                code: ffi::SQLITE_MISUSE,
+                message: format!("pos = {} + n = {} > size = {}", self.pos, n, size),
+            });
+        }
+        if n <= 0 {
+            return Ok(0);
+        }
+        let rc = unsafe {
+            ffi::sqlite3_blob_write(self.blob, mem::transmute(buf.as_ptr()), n, self.pos)
+        };
+        self.conn.decode_result(rc).map(|_| {
+            self.pos += n;
+            n
+        })
+    }
+
+    /// Seek to an offset, in bytes, in BLOB.
+    pub fn seek(&mut self, pos: SeekFrom) {
+        self.pos = match pos {
+            SeekFrom::Start(offset) => offset,
+            SeekFrom::Current(offset) => self.pos + offset,
+            SeekFrom::End(offset) => self.size() + offset,
+        };
+    }
+
+    /// Close a BLOB handle
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the underlying SQLite close call fails.
+    pub fn close(mut self) -> Result<()> {
+        self.close_()
+    }
+
+    fn close_(&mut self) -> Result<()> {
+        let rc = unsafe { ffi::sqlite3_blob_close(self.blob) };
+        self.blob = ptr::null_mut();
+        self.conn.decode_result(rc)
+    }
+}
+
+#[allow(unused_must_use)]
+impl<'conn> Drop for Blob<'conn> {
+    fn drop(&mut self) {
+        self.close_();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use Connection;
+
+    #[test]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn test_blob() {
+        let db = Connection::open_in_memory().unwrap();
+        let sql = "BEGIN;
+                CREATE TABLE test (content BLOB);
+                INSERT INTO test VALUES (ZEROBLOB(10));
+                END;";
+        db.execute_batch(sql).unwrap();
+        let rowid = db.last_insert_rowid();
+
+        let mut blob = db.blob_open("main", "test", "content", rowid, false).unwrap();
+        blob.write(b"Clob").unwrap();
+        let err = blob.write(b"5678901");
+        // writeln!(io::stderr(), "{:?}", err);
+        assert!(err.is_err());
+
+        assert!(blob.reopen(rowid).is_ok());
+        assert!(blob.close().is_ok());
+
+        blob = db.blob_open("main", "test", "content", rowid, true).unwrap();
+        let mut bytes = [0u8; 5];
+        assert_eq!(5, blob.read(&mut bytes[..]).unwrap());
+        assert_eq!(5, blob.read(&mut bytes[..]).unwrap());
+        assert_eq!(0, blob.read(&mut bytes[..]).unwrap());
+
+        assert!(blob.reopen(rowid).is_ok());
+        blob.seek(super::SeekFrom::Start(0));
+    }
+}

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -161,9 +161,9 @@ impl<'conn> io::Seek for Blob<'conn> {
         if pos < 0 {
             Err(io::Error::new(io::ErrorKind::InvalidInput,
                                "invalid seek to negative position"))
-        } else if pos > ::std::i32::MAX as i64 {
+        } else if pos > self.size() as i64 {
             Err(io::Error::new(io::ErrorKind::InvalidInput,
-                               "invalid seek to position > i32::MAX"))
+                               "invalid seek to position past end of blob"))
         } else {
             self.pos = pos as i32;
             Ok(pos as u64)
@@ -231,6 +231,11 @@ mod test {
         blob.reopen(rowid).unwrap();
         assert_eq!(5, blob.read(&mut bytes[..]).unwrap());
         assert_eq!(&bytes, b"Clob5");
+
+        // should not be able to seek negative or past end
+        assert!(blob.seek(SeekFrom::Current(-20)).is_err());
+        assert!(blob.seek(SeekFrom::End(0)).is_ok());
+        assert!(blob.seek(SeekFrom::Current(1)).is_err());
     }
 
     #[test]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -289,6 +289,11 @@ mod test {
         assert!(blob.seek(SeekFrom::Current(-20)).is_err());
         assert!(blob.seek(SeekFrom::End(0)).is_ok());
         assert!(blob.seek(SeekFrom::Current(1)).is_err());
+
+        // write_all should detect when we return Ok(0) because there is no space left,
+        // and return a write error
+        blob.reopen(rowid).unwrap();
+        assert!(blob.write_all(b"0123456789x").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod named_params;
 #[cfg(feature = "trace")]pub mod trace;
 #[cfg(feature = "backup")]pub mod backup;
 #[cfg(feature = "functions")] pub mod functions;
+#[cfg(feature = "blob")] pub mod blob;
 
 /// Old name for `Result`. `SqliteResult` is deprecated.
 pub type SqliteResult<T> = Result<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,9 +171,9 @@ pub enum DatabaseName<'a> {
     Attached(&'a str),
 }
 
-// Currently DatabaseName is only used by the backup mod, so hide this (private)
+// Currently DatabaseName is only used by the backup and blob mods, so hide this (private)
 // impl to avoid dead code warnings.
-#[cfg(feature = "backup")]
+#[cfg(any(feature = "backup", feature = "blob"))]
 impl<'a> DatabaseName<'a> {
     fn to_cstring(self) -> Result<CString> {
         use self::DatabaseName::{Main, Temp, Attached};


### PR DESCRIPTION
Builds on #58.

@gwenn Changes from #58:

* Moved read/write/seek out of `impl Blob` and into `impl std::io::{Read, Write, Seek}`s on `Blob`.
* Changed write to return `Ok(0)` instead of failing if asked to write more data than will fit in the blob. I'm not sure about this change, but I think it's more consistent with the way `std::io::Write` is expected to be implemented (e.g., `std::io::BufWriter` will return a `WriteZero` error if the underlying writer returns `Ok(0)` while it still has data buffered up that it wants to write).

I'm really on the fence with the change to `write`. What do you think?