### PR TITLE
Add test and check for SQLite being in single-threaded mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ version = "0.3.0"
 [[test]]
 name = "config_log"
 harness = false
+
+[[test]]
+name = "deny_single_threaded_sqlite_config"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
   `SqliteFailure` cases (which still include the error code but also include a Rust-friendlier
   enum as well), and rusqlite-level errors are captured in other cases. Because of this change,
   `SqliteError` no longer implements `PartialEq`.
+* BREAKING CHANGE: When opening a new detection, rusqlite now detects if SQLite was compiled or
+  configured for single-threaded use only; if it was, connection attempts will fail. If this
+  affects you, please open an issue.
 * BREAKING CHANGE: `SqliteTransactionDeferred`, `SqliteTransactionImmediate`, and
   `SqliteTransactionExclusive` are no longer exported. Instead, use
   `TransactionBehavior::Deferred`, `TransactionBehavior::Immediate`, and

--- a/tests/deny_single_threaded_sqlite_config.rs
+++ b/tests/deny_single_threaded_sqlite_config.rs
@@ -1,0 +1,20 @@
+//! Ensure we reject connections when SQLite is in single-threaded mode, as it
+//! would violate safety if multiple Rust threads tried to use connections.
+
+extern crate rusqlite;
+extern crate libsqlite3_sys as ffi;
+
+use rusqlite::Connection;
+
+#[test]
+fn test_error_when_singlethread_mode() {
+    // put SQLite into single-threaded mode
+    unsafe {
+        // 1 == SQLITE_CONFIG_SINGLETHREAD
+        assert_eq!(ffi::sqlite3_config(1), ffi::SQLITE_OK);
+        println!("{}", ffi::sqlite3_mutex_alloc(0) as u64);
+    }
+
+    let result = Connection::open_in_memory();
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Technically this is a breaking change - if any existing uses of rusqlite were linking against a single-threaded SQLite, or using `sqlite3_config()` to set single-threaded mode, connections will now fail. However, this change is a safety requirement given the API of rusqlite - `Connection`s can be opened on multiple rust threads, so we should fail fast if that isn't going to be safe.