### PR TITLE
Add support for user-defined aggregate functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ script:
     - cargo build
     - cargo test
     - cargo test --features backup
+    - cargo test --features blob
     - cargo test --features load_extension
     - cargo test --features trace
     - cargo test --features functions
-    - cargo test --features "backup functions load_extension trace"
+    - cargo test --features "backup blob functions load_extension trace"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 * Adds `column_count()` method to `Statement` and `Row`.
 * Adds `types::Value` for dynamic column types.
+* Adds support for user-defined aggregate functions (behind the existing `functions` Cargo feature).
 * Introduces a `RowIndex` trait allowing columns to be fetched via index (as before) or name (new).
 
 # Version 0.6.0 (2015-12-17)

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -342,7 +342,7 @@ pub trait Aggregate<A, T> where T: ToResult {
     /// "step" function called once for each row in an aggregate group.
     fn step(&self, &mut Context, &mut A) -> Result<()>;
     /// Computes and returns the final result.
-    fn finalize(&self, &A) -> Result<T>;
+    fn finalize(&self, A) -> Result<T>;
 }
 
 
@@ -549,7 +549,7 @@ impl InnerConnection {
             let ac: *mut A = *pac;
             let a = Box::from_raw(mem::transmute(ac)); // to be freed
 
-            match (*boxed_aggr).finalize(&a) {
+            match (*boxed_aggr).finalize(*a) {
                 Ok(r) => r.set_result(ctx),
                 Err(Error::SqliteFailure(err, s)) => {
                     ffi::sqlite3_result_error_code(ctx, err.extended_code);
@@ -783,8 +783,8 @@ mod test {
             Ok(())
         }
 
-        fn finalize(&self, sum: &i64) -> Result<i64> {
-            Ok(*sum)
+        fn finalize(&self, sum: i64) -> Result<i64> {
+            Ok(sum)
         }
     }
 


### PR DESCRIPTION
Builds on #108.

@gwenn I changed how step/finalize are called if there are no rows - see b189f6b. I think this is the right thing to do since otherwise you couldn't implement the `my_count` example in the unit tests (I don't believe?).