### PR TITLE
Add a `handle()` method to unsafely get the underlying SQLite connetion.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 * Introduces `ZeroBlob` type under the `blob` module/feature exposing SQLite's zeroblob API.
 * Adds CI testing for Windows via AppVeyor.
 * Fixes a warning building libsqlite3-sys under Rust 1.6.
+* Adds an unsafe `handle()` method to `Connection`. Please file an issue if you actually use it.
 
 # Version 0.6.0 (2015-12-17)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,18 @@ impl Connection {
             self.db.borrow_mut().load_extension(dylib_path.as_ref(), entry_point)
         }
 
+    /// Get access to the underlying SQLite database connection handle.
+    ///
+    /// # Warning
+    ///
+    /// You should not need to use this function. If you do need to, please [open an issue
+    /// on the rusqlite repository](https://github.com/jgallagher/rusqlite/issues) and describe
+    /// your use case. This function is unsafe because it gives you raw access to the SQLite
+    /// connection, and what you do with it could impact the safety of this `Connection`.
+    pub unsafe fn handle(&self) -> *mut ffi::Struct_sqlite3 {
+        self.db.borrow().db()
+    }
+
     fn decode_result(&self, code: c_int) -> Result<()> {
         self.db.borrow_mut().decode_result(code)
     }


### PR DESCRIPTION
Closes #21.

Doc comments suggest opening issues on rusqlite for any uses of
`handle()`, as uses indicate areas where rusqlite insufficiently wraps
SQLite.