### PR TITLE
Remove load_extension feature from the binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "rusqlite"
 
 [features]
-load_extension = ["libsqlite3-sys/load_extension"]
+load_extension = []
 backup = []
 blob = []
 functions = []

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -8,9 +8,6 @@ license = "MIT"
 links = "sqlite3"
 build = "build.rs"
 
-[features]
-load_extension = []
-
 [build-dependencies]
 pkg-config = "~0.3"
 


### PR DESCRIPTION
It doesn't seem to me "load_extension" is used anywhere inside libsqlite3-sys.