### PR TITLE
Fix crash due to 0-sized function type change in nightly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Version UPCOMING (...)
 
+* Fixes crash on nightly Rust when using the `trace` feature.
 * Adds optional `clippy` feature and addresses issues it found.
 * Adds `column_count()` method to `Statement` and `Row`.
 * Adds `types::Value` for dynamic column types.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -35,7 +35,9 @@ pub unsafe fn config_log(callback: Option<fn(c_int, &str)>) -> Result<()> {
     let rc = match callback {
         Some(f) => {
             let p_arg: *mut c_void = mem::transmute(f);
-            ffi::sqlite3_config(ffi::SQLITE_CONFIG_LOG, Some(log_callback), p_arg)
+            ffi::sqlite3_config(ffi::SQLITE_CONFIG_LOG,
+                                log_callback as extern "C" fn(_, _, _),
+                                p_arg)
         }
         None => {
             let nullptr: *mut c_void = ptr::null_mut();


### PR DESCRIPTION
Filed an [issue on rustc](https://github.com/rust-lang/rust/issues/32588) discussion the quietness of this break.