### PR TITLE
linking against alternate implementations

### DIFF
--- a/libsqlite3-sys/src/bindgen.rs
+++ b/libsqlite3-sys/src/bindgen.rs
@@ -793,13 +793,11 @@ impl ::std::clone::Clone for Struct___va_list_tag {
 impl ::std::default::Default for Struct___va_list_tag {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
-#[link(name = "sqlite3")]
 extern "C" {
     pub static mut sqlite3_version: *const ::libc::c_char;
     pub static mut sqlite3_temp_directory: *mut ::libc::c_char;
     pub static mut sqlite3_data_directory: *mut ::libc::c_char;
 }
-#[link(name = "sqlite3")]
 extern "C" {
     pub fn sqlite3_libversion() -> *const ::libc::c_char;
     pub fn sqlite3_sourceid() -> *const ::libc::c_char;


### PR DESCRIPTION
I apologize if this is a bit long winded, it's probably because I have no idea what I'm doing :-)

This is my first time trying Rust, and I'd like to develop an application with Rust using [SqlCipher](https://www.zetetic.net/sqlcipher/). There doesn't appear to be anything already in Cargo already for it, but given that it's a drop in replacement, I figure Rusqlite should work fine. I'd rather not maintain a fork so I started looking into if I could just override it to link against SqlCipher at build time. Sure enough cargo has a section on [overriding build scripts](http://doc.crates.io/build-script.html#overriding-build-scripts).

After messing with it a bit, I wind up with:
`.cargo/config`
```toml
[target.x86_64-unknown-linux-gnu.sqlite3]
rustc-link-lib = ["sqlcipher"]
rustc-link-search = ["/usr/lib"]
```

However `ldd` still says my application is linked against `libsqlite3.so`. After a couple evenings I worked out that if I remove the `#[link(name = "sqlite3")]`, everything still appears to build fine, but my override works. After some more playing around, it appears that everything compiles fine as long as either `build.rs` has instructions for linking *or* `bindgen.rs` has the `link` lines, with `bindgen.rs` winning if both exist.

Researching a bit more, it looks like I might also be able to control the `link` in `bindgen` using [cfg_attr](https://doc.rust-lang.org/stable/book/conditional-compilation.html#cfg_attr) and the like, but I'm not really sure the difference between that and linking in the `build.rs` script.

Which leads to my question/request... do you have any advice on how best to approach this? And if I were to try to get it working would you be interested in having the capability in Rusqlite?