### PR TITLE
From/ToSql for chrono types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ script:
     - cargo test --features load_extension
     - cargo test --features trace
     - cargo test --features functions
-    - cargo test --features "backup blob functions load_extension trace"
+    - cargo test --features chrono
+    - cargo test --features "backup blob chrono functions load_extension trace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ trace = []
 time = "~0.1.0"
 bitflags = "~0.1"
 libc = "~0.2"
+chrono = { version = "~0.2", optional = true }
 
 [dev-dependencies]
 tempdir = "~0.3.4"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Version UPCOMING (...)
 
+* Adds support for serializing types from the `chrono` crate. Requires the `chrono` feature.
 * Removes `load_extension` feature from `libsqlite3-sys`. `load_extension` is still available
   on rusqlite itself.
 * Fixes crash on nightly Rust when using the `trace` feature.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build: false
 
 test_script:
   - cargo test --lib --verbose
-  - cargo test --lib --features "backup blob functions load_extension trace"
+  - cargo test --lib --features "backup blob chrono functions load_extension trace"
 
 cache:
   - C:\Users\appveyor\.cargo

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -272,39 +272,39 @@ mod test {
     #[test]
     fn test_naive_date() {
         let db = checked_memory_handle();
-        let d = NaiveDate::from_ymd(2016, 2, 23);
-        db.execute("INSERT INTO foo (t) VALUES (?)", &[&d]).unwrap();
+        let date = NaiveDate::from_ymd(2016, 2, 23);
+        db.execute("INSERT INTO foo (t) VALUES (?)", &[&date]).unwrap();
         db.execute("UPDATE foo SET f = julianday(t)", &[]).unwrap();
 
         let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!("2016-02-23", s);
         let t: NaiveDate = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(d, t);
+        assert_eq!(date, t);
         let f: NaiveDate = db.query_row("SELECT f FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(d, f);
+        assert_eq!(date, f);
     }
 
     #[test]
     fn test_naive_time() {
         let db = checked_memory_handle();
-        let t = NaiveTime::from_hms(23, 56, 4);
-        db.execute("INSERT INTO foo (t) VALUES (?)", &[&t]).unwrap();
+        let time = NaiveTime::from_hms(23, 56, 4);
+        db.execute("INSERT INTO foo (t) VALUES (?)", &[&time]).unwrap();
 
         let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!("23:56:04", s);
         let v: NaiveTime = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(t, v);
+        assert_eq!(time, v);
     }
 
     #[test]
     fn test_naive_date_time() {
         let db = checked_memory_handle();
-        let d = NaiveDate::from_ymd(2016, 2, 23);
-        let t = NaiveTime::from_hms(23, 56, 4);
-        let dt = NaiveDateTime::new(d, t);
+        let date = NaiveDate::from_ymd(2016, 2, 23);
+        let time = NaiveTime::from_hms(23, 56, 4);
+        let dt = NaiveDateTime::new(date, time);
 
-        let di = NaiveDateTime::new(d, NaiveTime::from_hms(23, 56, 3));
-        let ds = NaiveDateTime::new(d, NaiveTime::from_hms(23, 56, 5));
+        let di = NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 3));
+        let ds = NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 5));
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&dt]).unwrap();
         db.execute("UPDATE foo SET f = julianday(t), i = strftime('%s', t)",
@@ -327,15 +327,15 @@ mod test {
 
         db.execute("UPDATE foo set b = strftime('%Y-%m-%dT%H:%M', t)", &[]).unwrap();
         let b: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(NaiveDateTime::new(d, NaiveTime::from_hms(23, 56, 0)), b);
+        assert_eq!(NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 0)), b);
     }
 
     #[test]
     fn test_date_time_utc() {
         let db = checked_memory_handle();
-        let d = NaiveDate::from_ymd(2016, 2, 23);
-        let t = NaiveTime::from_hms(23, 56, 4);
-        let dt = NaiveDateTime::new(d, t);
+        let date = NaiveDate::from_ymd(2016, 2, 23);
+        let time = NaiveTime::from_hms(23, 56, 4);
+        let dt = NaiveDateTime::new(date, time);
         let utc = UTC.from_utc_datetime(&dt);
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&utc]).unwrap();
@@ -354,9 +354,9 @@ mod test {
     #[test]
     fn test_date_time_local() {
         let db = checked_memory_handle();
-        let d = NaiveDate::from_ymd(2016, 2, 23);
-        let t = NaiveTime::from_hms(23, 56, 4);
-        let dt = NaiveDateTime::new(d, t);
+        let date = NaiveDate::from_ymd(2016, 2, 23);
+        let time = NaiveTime::from_hms(23, 56, 4);
+        let dt = NaiveDateTime::new(date, time);
         let local = Local.from_local_datetime(&dt).single().unwrap();
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&local]).unwrap();

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -322,12 +322,12 @@ mod test {
         assert_eq!(dt, i);
 
         db.execute("UPDATE foo set b = datetime(t)", &[]).unwrap(); // "YYYY-MM-DD HH:MM:SS"
-        let b: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(dt, b);
+        let hms: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(dt, hms);
 
         db.execute("UPDATE foo set b = strftime('%Y-%m-%dT%H:%M', t)", &[]).unwrap();
-        let b: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 0)), b);
+        let hm: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 0)), hm);
     }
 
     #[test]

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -372,8 +372,8 @@ mod test {
                    &[])
           .unwrap();
 
-        let s: String = db.query_row("SELECT t FROM chrono", &[], |r| r.get(0)).unwrap();
-        assert_eq!("2016-02-23 23:56:04.000+01:00", s);
+        //let s: String = db.query_row("SELECT t FROM chrono", &[], |r| r.get(0)).unwrap();
+        //assert_eq!("2016-02-23 23:56:04.000+01:00", s);
         let v: DateTime<Local> = db.query_row("SELECT t FROM chrono", &[], |r| r.get(0)).unwrap();
         assert_eq!(local, v);
         let i: DateTime<Local> = db.query_row("SELECT i FROM chrono", &[], |r| r.get(0)).unwrap();

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -68,8 +68,8 @@ impl ToSql for NaiveDateTime {
     }
 }
 
-/// "YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS" => ISO 8601 combined date and time without timezone.
-/// ("YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
+/// "YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS" => ISO 8601 combined date and time
+/// without timezone. ("YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
 impl FromSql for NaiveDateTime {
     unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<NaiveDateTime> {
         let s = try!(String::column_result(stmt, col));
@@ -138,7 +138,8 @@ impl FromSql for DateTime<Local> {
 #[cfg(test)]
 mod test {
     use Connection;
-    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, UTC, Duration};
+    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, UTC,
+                        Duration};
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -205,13 +206,16 @@ mod test {
         let v1: DateTime<UTC> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(utc, v1);
 
-        let v2: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04.789'", &[], |r| r.get(0)).unwrap();
+        let v2: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04.789'", &[], |r| r.get(0))
+            .unwrap();
         assert_eq!(utc, v2);
 
-        let v3: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04'", &[], |r| r.get(0)).unwrap();
+        let v3: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04'", &[], |r| r.get(0))
+            .unwrap();
         assert_eq!(utc - Duration::milliseconds(789), v3);
 
-        let v4: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04.789+00:00'", &[], |r| r.get(0)).unwrap();
+        let v4: DateTime<UTC> =
+            db.query_row("SELECT '2016-02-23 23:56:04.789+00:00'", &[], |r| r.get(0)).unwrap();
         assert_eq!(utc, v4);
     }
 

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -129,7 +129,7 @@ impl FromSql for DateTime<Local> {
 #[cfg(test)]
 mod test {
     use Connection;
-    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, UTC};
+    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, UTC, Duration};
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -192,8 +192,15 @@ mod test {
 
         let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!("2016-02-23T23:56:04.789+00:00", s);
-        let v: DateTime<UTC> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(utc, v);
+
+        let v1: DateTime<UTC> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(utc, v1);
+
+        let v2: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04.789'", &[], |r| r.get(0)).unwrap();
+        assert_eq!(utc, v2);
+
+        let v3: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04'", &[], |r| r.get(0)).unwrap();
+        assert_eq!(utc - Duration::milliseconds(789), v3);
     }
 
     #[test]

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -1,19 +1,13 @@
 //! Convert most of the [Time Strings](http://sqlite.org/lang_datefunc.html) to chrono types.
 extern crate chrono;
 
-use std::error;
 use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, UTC, Local};
 use libc::c_int;
 
 use {Error, Result};
 use types::{FromSql, ToSql};
 
-use ffi;
 use ffi::sqlite3_stmt;
-use ffi::sqlite3_column_type;
-
-const JULIAN_DAY: f64 = 2440587.5; // 1970-01-01 00:00:00 is JD 2440587.5
-const DAY_IN_SECONDS: f64 = 86400.0;
 
 /// ISO 8601 calendar date without timezone => "YYYY-MM-DD"
 impl ToSql for NaiveDate {
@@ -69,158 +63,67 @@ impl FromSql for NaiveTime {
 /// ISO 8601 combined date and time without timezone => "YYYY-MM-DD HH:MM:SS.SSS"
 impl ToSql for NaiveDateTime {
     unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
-        let date_str = self.format("%Y-%m-%d %H:%M:%S%.f").to_string();
+        let date_str = self.format("%Y-%m-%dT%H:%M:%S%.f").to_string();
         date_str.bind_parameter(stmt, col)
     }
 }
 
-/// "YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 combined date and time without timezone.
-/// ("YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
+/// "YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS" => ISO 8601 combined date and time without timezone.
+/// ("YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
 impl FromSql for NaiveDateTime {
     unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<NaiveDateTime> {
-        match sqlite3_column_type(stmt, col) {
-            ffi::SQLITE_TEXT => {
-                let s = try!(String::column_result(stmt, col));
-                let fmt = match s.len() {
-                    16 => {
-                        match s.as_bytes()[10] {
-                            b'T' => "%Y-%m-%dT%H:%M",
-                            _ => "%Y-%m-%d %H:%M",
-                        }
-                    }
-                    19 => {
-                        match s.as_bytes()[10] {
-                            b'T' => "%Y-%m-%dT%H:%M:%S",
-                            _ => "%Y-%m-%d %H:%M:%S",
-                        }
-                    }
-                    _ => {
-                        match s.as_bytes()[10] {
-                            b'T' => "%Y-%m-%dT%H:%M:%S%.f",
-                            _ => "%Y-%m-%d %H:%M:%S%.f",
-                        }
-                    }
-                };
-                match NaiveDateTime::parse_from_str(&s, fmt) {
-                    Ok(dt) => Ok(dt),
-                    Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
-                }
-            }
-            ffi::SQLITE_INTEGER => {
-                match NaiveDateTime::from_timestamp_opt(ffi::sqlite3_column_int64(stmt, col), 0) {
-                    Some(dt) => Ok(dt),
-                    None => {
-                        let err: Box<error::Error + Sync + Send> = "out-of-range number of seconds"
-                                                                       .into();
-                        Err(Error::FromSqlConversionFailure(err))
-                    }
-                }
-            }
-            ffi::SQLITE_FLOAT => {
-                // if column affinity is REAL and an integer/unix timestamp is inserted => unexpected result
-                let mut jd = ffi::sqlite3_column_double(stmt, col);
-                jd -= JULIAN_DAY;
-                jd *= DAY_IN_SECONDS;
-                let ns = jd.fract() * 10f64.powi(9);
-                match NaiveDateTime::from_timestamp_opt(jd as i64, ns as u32) {
-                    Some(dt) => Ok(dt),
-                    None => {
-                        let err: Box<error::Error + Sync + Send> = "out-of-range number of \
-                                                                    seconds and/or invalid \
-                                                                    nanosecond"
-                                                                       .into();
-                        Err(Error::FromSqlConversionFailure(err))
-                    }
-                }
-            }
-            _ => Err(Error::InvalidColumnType),
+        let s = try!(String::column_result(stmt, col));
+
+        let fmt = if s.len() >= 11 && s.as_bytes()[10] == b'T' {
+            "%Y-%m-%dT%H:%M:%S%.f"
+        } else {
+            "%Y-%m-%d %H:%M:%S%.f"
+        };
+
+        match NaiveDateTime::parse_from_str(&s, fmt) {
+            Ok(dt) => Ok(dt),
+            Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
         }
     }
-}
 
-/// ISO 8601 date and time with time zone => "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"
-impl ToSql for DateTime<UTC> {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
-        let date_str = self.format("%Y-%m-%d %H:%M:%S%.f%:z").to_string();
-        date_str.bind_parameter(stmt, col)
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        String::column_has_valid_sqlite_type(stmt, col)
     }
 }
 
-/// "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 date and time with time zone.
-/// ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
-/// When the timezone is not specified, UTC is used.
+/// Date and time with time zone => RFC3339 timestamp ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM").
+impl<Tz: TimeZone> ToSql for DateTime<Tz> where Tz::Offset: ::std::fmt::Display {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        self.to_rfc3339().bind_parameter(stmt, col)
+    }
+}
+
+/// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<UTC>.
 impl FromSql for DateTime<UTC> {
     unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<DateTime<UTC>> {
-        match sqlite3_column_type(stmt, col) {
-            ffi::SQLITE_TEXT => {
-                let mut s = try!(String::column_result(stmt, col));
-                if s.len() > 23 {
-                    if s.as_bytes()[10] == b' ' {
-                        s.as_mut_vec()[10] = b'T';
-                    };
-                    // It cannot be used when the offset can be missing.
-                    match DateTime::parse_from_rfc3339(&s) {
-                        Ok(dt) => Ok(dt.with_timezone(&UTC)),
-                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
-                    }
-                } else {
-                    NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
-                }
-            }
-            ffi::SQLITE_INTEGER => {
-                NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
-            }
-            ffi::SQLITE_FLOAT => {
-                NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
-            }
-            _ => Err(Error::InvalidColumnType),
+        let s = try!(String::column_result(stmt, col));
+        match DateTime::parse_from_rfc3339(&s) {
+            Ok(dt) => Ok(dt.with_timezone(&UTC)),
+            Err(_) => NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt)),
         }
     }
-}
 
-
-/// ISO 8601 date and time with time zone => "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"
-impl ToSql for DateTime<Local> {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
-        let date_str = self.format("%Y-%m-%d %H:%M:%S%.f%:z").to_string();
-        date_str.bind_parameter(stmt, col)
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        String::column_has_valid_sqlite_type(stmt, col)
     }
 }
 
-/// "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 date and time with time zone.
-/// ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
-/// When the timezone is not specified, UTC is used.
+/// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<Local>.
 impl FromSql for DateTime<Local> {
     unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<DateTime<Local>> {
-        match sqlite3_column_type(stmt, col) {
-            ffi::SQLITE_TEXT => {
-                let mut s = try!(String::column_result(stmt, col));
-                if s.len() > 23 {
-                    if s.as_bytes()[10] == b' ' {
-                        s.as_mut_vec()[10] = b'T';
-                    };
-                    // It cannot be used when the offset can be missing.
-                    match DateTime::parse_from_rfc3339(&s) {
-                        Ok(dt) => Ok(dt.with_timezone(&Local)),
-                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
-                    }
-                } else {
-                    NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
-                }
-            }
-            ffi::SQLITE_INTEGER => {
-                NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
-            }
-            ffi::SQLITE_FLOAT => {
-                NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
-            }
-            _ => Err(Error::InvalidColumnType),
-        }
+        let utc_dt = try!(DateTime::<UTC>::column_result(stmt, col));
+        Ok(utc_dt.with_timezone(&Local))
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        DateTime::<UTC>::column_has_valid_sqlite_type(stmt, col)
     }
 }
-
-// struct UnixTime(NaiveDateTime);
-// struct JulianTime(NaiveDateTime)
 
 #[cfg(test)]
 mod test {
@@ -264,117 +167,48 @@ mod test {
         let time = NaiveTime::from_hms(23, 56, 4);
         let dt = NaiveDateTime::new(date, time);
 
-        let di = NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 3));
-        let ds = NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 5));
-
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&dt]).unwrap();
-        db.execute("UPDATE foo SET f = julianday(t), i = strftime('%s', t)",
-                   &[])
-          .unwrap();
 
         let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!("2016-02-23 23:56:04", s);
+        assert_eq!("2016-02-23T23:56:04", s);
         let v: NaiveDateTime = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(dt, v);
-        let f: NaiveDateTime = db.query_row("SELECT f FROM foo", &[], |r| r.get(0)).unwrap();
-        // `2016-02-23T23:56:04` vs `2016-02-23T23:56:03.999992609`
-        assert!(f.ge(&di) && f.le(&ds));
-        let i: NaiveDateTime = db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(dt, i);
 
         db.execute("UPDATE foo set b = datetime(t)", &[]).unwrap(); // "YYYY-MM-DD HH:MM:SS"
         let hms: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(dt, hms);
-
-        db.execute("UPDATE foo set b = strftime('%Y-%m-%dT%H:%M', t)", &[]).unwrap();
-        let hm: NaiveDateTime = db.query_row("SELECT b FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(NaiveDateTime::new(date, NaiveTime::from_hms(23, 56, 0)), hm);
     }
 
     #[test]
     fn test_date_time_utc() {
         let db = checked_memory_handle();
         let date = NaiveDate::from_ymd(2016, 2, 23);
-        let time = NaiveTime::from_hms(23, 56, 4);
+        let time = NaiveTime::from_hms_milli(23, 56, 4, 789);
         let dt = NaiveDateTime::new(date, time);
         let utc = UTC.from_utc_datetime(&dt);
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&utc]).unwrap();
-        db.execute("UPDATE foo SET f = julianday(t), i = strftime('%s', t)",
-                   &[])
-          .unwrap();
 
         let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!("2016-02-23 23:56:04+00:00", s);
+        assert_eq!("2016-02-23T23:56:04.789+00:00", s);
         let v: DateTime<UTC> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(utc, v);
-        let i: DateTime<UTC> = db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(utc, i);
     }
 
     #[test]
     fn test_date_time_local() {
         let db = checked_memory_handle();
         let date = NaiveDate::from_ymd(2016, 2, 23);
-        let time = NaiveTime::from_hms(23, 56, 4);
+        let time = NaiveTime::from_hms_milli(23, 56, 4, 789);
         let dt = NaiveDateTime::new(date, time);
         let local = Local.from_local_datetime(&dt).single().unwrap();
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&local]).unwrap();
-        db.execute("UPDATE foo SET f = julianday(t), i = strftime('%s', t)",
-                   &[])
-          .unwrap();
 
-        // let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
-        // assert_eq!("2016-02-23 23:56:04.000+01:00", s);
+        let s: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
+        let offset = Local.offset_from_utc_datetime(&dt);
+        assert_eq!(format!("2016-02-23T23:56:04.789{:}", offset), s);
         let v: DateTime<Local> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(local, v);
-        let i: DateTime<Local> = db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(local, i);
-    }
-
-    #[test]
-    fn test_timezone() {
-        // Worst
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471+08:00",
-                              "%Y-%m-%d %H:%M:%S%.f%:z")
-           .unwrap_err();
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471Z", "%Y-%m-%d %H:%M:%S%.f%:z")
-           .unwrap_err();
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471", "%Y-%m-%d %H:%M:%S%.f%:z").unwrap_err();
-
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471+08:00", "%Y-%m-%d %H:%M:%S%.f%z")
-           .unwrap_err();
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471Z", "%Y-%m-%d %H:%M:%S%.f%z").unwrap_err();
-        UTC.datetime_from_str("2016-05-04 17:00:42.862471", "%Y-%m-%d %H:%M:%S%.f%z").unwrap_err();
-
-        // Better but...
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471+08:00", "%Y-%m-%d %H:%M:%S%.f%z")
-            .unwrap()
-            .with_timezone(&UTC);
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471Z", "%Y-%m-%d %H:%M:%S%.f%z")
-            .unwrap_err(); // Invalid
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471", "%Y-%m-%d %H:%M:%S%.f%z")
-            .unwrap_err(); // TooShort
-
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471+08:00",
-                                 "%Y-%m-%d %H:%M:%S%.f%:z")
-            .unwrap()
-            .with_timezone(&UTC);
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471Z", "%Y-%m-%d %H:%M:%S%.f%:z")
-            .unwrap_err(); // Invalid
-        DateTime::parse_from_str("2016-05-04 17:00:42.862471", "%Y-%m-%d %H:%M:%S%.f%:z")
-            .unwrap_err(); // TooShort
-
-        // Best but in SQLite, the timezone indicator is optional
-        DateTime::parse_from_rfc3339("2016-05-04T17:00:42.862471+08:00")
-            .unwrap()
-            .with_timezone(&UTC);
-        DateTime::parse_from_rfc3339("2016-05-04T17:00:42.862471Z").unwrap().with_timezone(&UTC);
-        DateTime::parse_from_rfc3339("2016-05-04T17:00:42.862471").unwrap_err(); // TooShort
-
-        "2016-05-04T17:00:42.862471+08:00".parse::<DateTime<UTC>>().unwrap();
-        "2016-05-04T17:00:42.862471Z".parse::<DateTime<UTC>>().unwrap();
-        "2016-05-04T17:00:42.862471".parse::<DateTime<UTC>>().unwrap_err(); // TooShort
     }
 }

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -54,10 +54,6 @@ impl FromSql for NaiveDate {
             _ => Err(Error::InvalidColumnType),
         }
     }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true // to avoid double check
-    }
 }
 
 /// ISO 8601 time without timezone => "HH:MM:SS.SSS"
@@ -158,10 +154,6 @@ impl FromSql for NaiveDateTime {
             _ => Err(Error::InvalidColumnType),
         }
     }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true // to avoid double check
-    }
 }
 
 /// ISO 8601 date and time with time zone => "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"
@@ -201,10 +193,6 @@ impl FromSql for DateTime<UTC> {
             }
             _ => Err(Error::InvalidColumnType),
         }
-    }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true // to avoid double check
     }
 }
 
@@ -246,10 +234,6 @@ impl FromSql for DateTime<Local> {
             }
             _ => Err(Error::InvalidColumnType),
         }
-    }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true // to avoid double check
     }
 }
 

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -1,0 +1,267 @@
+//! Convert most of the [Time Strings](http://sqlite.org/lang_datefunc.html) to chrono types.
+extern crate chrono;
+
+use std::error;
+use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, UTC, Local};
+use libc::c_int;
+
+use {Error, Result};
+use types::{FromSql, ToSql};
+
+use ffi;
+use ffi::sqlite3_stmt;
+use ffi::sqlite3_column_type;
+
+const JULIAN_DAY: f64 = 2440587.5; // 1970-01-01 00:00:00 is JD 2440587.5
+const DAY_IN_SECONDS: f64 = 86400.0;
+const JULIAN_DAY_GREGORIAN: f64 = 1721424.5; // Jan 1, 1 proleptic Gregorian calendar
+
+/// ISO 8601 calendar date without timezone => "YYYY-MM-DD"
+impl ToSql for NaiveDate {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let date_str = self.format("%Y-%m-%d").to_string();
+        date_str.bind_parameter(stmt, col)
+    }
+}
+
+/// "YYYY-MM-DD" or Julian Day => ISO 8601 calendar date without timezone.
+impl FromSql for NaiveDate {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<NaiveDate> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let s = try!(String::column_result(stmt, col));
+                match NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
+                    Ok(dt) => Ok(dt),
+                    Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                }
+            }
+            ffi::SQLITE_FLOAT => {
+                // if column affinity is REAL and an integer/unix timestamp is inserted => unexpected result
+                let mut jd = ffi::sqlite3_column_double(stmt, col);
+                jd -= JULIAN_DAY_GREGORIAN;
+                if jd < i32::min_value() as f64 || jd > i32::max_value() as f64 {
+                    let err: Box<error::Error + Sync + Send> = "out-of-range date".into();
+                    return Err(Error::FromSqlConversionFailure(err));
+                }
+                match NaiveDate::from_num_days_from_ce_opt(jd as i32) {
+                    Some(dt) => Ok(dt),
+                    None => {
+                        let err: Box<error::Error + Sync + Send> = "out-of-range date".into();
+                        Err(Error::FromSqlConversionFailure(err))
+                    }
+                }
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        let sqlite_type = sqlite3_column_type(stmt, col);
+        sqlite_type == ffi::SQLITE_TEXT || sqlite_type == ffi::SQLITE_FLOAT
+    }
+}
+
+/// ISO 8601 time without timezone => "HH:MM:SS.SSS"
+impl ToSql for NaiveTime {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let date_str = self.format("%H:%M:%S.3f").to_string();
+        date_str.bind_parameter(stmt, col)
+    }
+}
+
+/// "HH:MM"/"HH:MM:SS"/"HH:MM:SS.SSS" => ISO 8601 time without timezone.
+impl FromSql for NaiveTime {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<NaiveTime> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let s = try!(String::column_result(stmt, col));
+                let fmt = match s.len() {
+                    5 => "%H:%M",
+                    8 => "%H:%M:%S",
+                    _ => "%H:%M:%S%.3f",
+                };
+                match NaiveTime::parse_from_str(&s, fmt) {
+                    Ok(dt) => Ok(dt),
+                    Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                }
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        sqlite3_column_type(stmt, col) == ffi::SQLITE_TEXT
+    }
+}
+
+/// ISO 8601 combined date and time without timezone => "YYYY-MM-DD HH:MM:SS.SSS"
+impl ToSql for NaiveDateTime {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let date_str = self.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+        date_str.bind_parameter(stmt, col)
+    }
+}
+
+/// "YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 combined date and time without timezone.
+/// ("YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
+impl FromSql for NaiveDateTime {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<NaiveDateTime> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let s = try!(String::column_result(stmt, col));
+                let fmt = match s.len() {
+                    16 => {
+                        match s.as_bytes()[10] {
+                            b'T' => "%Y-%m-%dT%H:%M",
+                            _ => "%Y-%m-%d %H:%M",
+                        }
+                    }
+                    19 => {
+                        match s.as_bytes()[10] {
+                            b'T' => "%Y-%m-%dT%H:%M:%S",
+                            _ => "%Y-%m-%d %H:%M:%S",
+                        }
+                    }
+                    _ => {
+                        match s.as_bytes()[10] {
+                            b'T' => "%Y-%m-%dT%H:%M:%S%.3f",
+                            _ => "%Y-%m-%d %H:%M:%S%.3f",
+                        }
+                    }
+                };
+                match NaiveDateTime::parse_from_str(&s, fmt) {
+                    Ok(dt) => Ok(dt),
+                    Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                }
+            }
+            ffi::SQLITE_INTEGER => {
+                match NaiveDateTime::from_timestamp_opt(ffi::sqlite3_column_int64(stmt, col), 0) {
+                    Some(dt) => Ok(dt),
+                    None => {
+                        let err: Box<error::Error + Sync + Send> = "out-of-range number of seconds"
+                                                                       .into();
+                        Err(Error::FromSqlConversionFailure(err))
+                    }
+                }
+            }
+            ffi::SQLITE_FLOAT => {
+                // if column affinity is REAL and an integer/unix timestamp is inserted => unexpected result
+                let mut jd = ffi::sqlite3_column_double(stmt, col);
+                jd -= JULIAN_DAY;
+                jd *= DAY_IN_SECONDS;
+                let ns = jd.fract() * 10f64.powi(9);
+                match NaiveDateTime::from_timestamp_opt(jd as i64, ns as u32) {
+                    Some(dt) => Ok(dt),
+                    None => {
+                        let err: Box<error::Error + Sync + Send> = "out-of-range number of \
+                                                                    seconds and/or invalid \
+                                                                    nanosecond"
+                                                                       .into();
+                        Err(Error::FromSqlConversionFailure(err))
+                    }
+                }
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        let sqlite_type = sqlite3_column_type(stmt, col);
+        sqlite_type == ffi::SQLITE_TEXT || sqlite_type == ffi::SQLITE_INTEGER ||
+        sqlite_type == ffi::SQLITE_FLOAT
+    }
+}
+
+/// ISO 8601 date and time with time zone => "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"
+impl ToSql for DateTime<UTC> {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let date_str = self.format("%Y-%m-%dT%H:%M:%S%.3f%:z").to_string();
+        date_str.bind_parameter(stmt, col)
+    }
+}
+
+/// "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 date and time with time zone.
+/// ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
+/// When the timezone is not specified, UTC is used.
+impl FromSql for DateTime<UTC> {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<DateTime<UTC>> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let s = try!(String::column_result(stmt, col));
+                if s.len() > 23 {
+                    let fmt = if s.as_bytes()[10] == b'T' {
+                        "%Y-%m-%dT%H:%M:%S%.3f%:z"
+                    } else {
+                        "%Y-%m-%d %H:%M:%S%.3f%:z"
+                    };
+                    match UTC.datetime_from_str(fmt, &s) {
+                        Ok(dt) => Ok(dt),
+                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                    }
+                } else {
+                    NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
+                }
+            }
+            ffi::SQLITE_INTEGER => {
+                NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
+            }
+            ffi::SQLITE_FLOAT => {
+                NaiveDateTime::column_result(stmt, col).map(|dt| UTC.from_utc_datetime(&dt))
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        NaiveDateTime::column_has_valid_sqlite_type(stmt, col)
+    }
+}
+
+
+/// ISO 8601 date and time with time zone => "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"
+impl ToSql for DateTime<Local> {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let date_str = self.format("%Y-%m-%dT%H:%M:%S%.3f%:z").to_string();
+        date_str.bind_parameter(stmt, col)
+    }
+}
+
+/// "YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DD HH:MM"/"YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS"/ Julian Day / Unix Time => ISO 8601 date and time with time zone.
+/// ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM"/"YYYY-MM-DDTHH:MM"/"YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
+/// When the timezone is not specified, Local is used.
+impl FromSql for DateTime<Local> {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<DateTime<Local>> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let s = try!(String::column_result(stmt, col));
+                if s.len() > 23 {
+                    let fmt = if s.as_bytes()[10] == b'T' {
+                        "%Y-%m-%dT%H:%M:%S%.3f%:z"
+                    } else {
+                        "%Y-%m-%d %H:%M:%S%.3f%:z"
+                    };
+                    match Local.datetime_from_str(fmt, &s) {
+                        Ok(dt) => Ok(dt),
+                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                    }
+                } else {
+                    NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
+                }
+            }
+            ffi::SQLITE_INTEGER => {
+                NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
+            }
+            ffi::SQLITE_FLOAT => {
+                NaiveDateTime::column_result(stmt, col).map(|dt| Local.from_utc_datetime(&dt))
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        NaiveDateTime::column_has_valid_sqlite_type(stmt, col)
+    }
+}
+
+// struct UnixTime(NaiveDateTime);
+// struct JulianTime(NaiveDateTime)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -66,6 +66,9 @@ pub use ffi::sqlite3_column_type;
 
 pub use ffi::{SQLITE_INTEGER, SQLITE_FLOAT, SQLITE_TEXT, SQLITE_BLOB, SQLITE_NULL};
 
+#[cfg(feature = "chrono")]
+mod chrono;
+
 const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
 
 /// A trait for types that can be converted into SQLite values.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -298,10 +298,6 @@ impl FromSql for Value {
             _ => Err(Error::InvalidColumnType),
         }
     }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true
-    }
 }
 
 #[cfg(test)]

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,0 +1,81 @@
+extern crate time;
+
+use libc::c_int;
+use {Error, Result};
+use types::{FromSql, ToSql};
+
+use ffi;
+use ffi::sqlite3_stmt;
+use ffi::sqlite3_column_type;
+
+const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
+const JULIAN_DAY: f64 = 2440587.5; // 1970-01-01 00:00:00 is JD 2440587.5
+const DAY_IN_SECONDS: f64 = 86400.0;
+
+impl ToSql for time::Timespec {
+    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+        let time_str = time::at_utc(*self).strftime(SQLITE_DATETIME_FMT).unwrap().to_string();
+        time_str.bind_parameter(stmt, col)
+    }
+}
+
+impl FromSql for time::Timespec {
+    unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<time::Timespec> {
+        match sqlite3_column_type(stmt, col) {
+            ffi::SQLITE_TEXT => {
+                let col_str = FromSql::column_result(stmt, col);
+                col_str.and_then(|txt: String| {
+                    match time::strptime(&txt, SQLITE_DATETIME_FMT) {
+                        Ok(tm) => Ok(tm.to_timespec()),
+                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                    }
+                })
+            }
+            ffi::SQLITE_INTEGER => Ok(time::Timespec::new(ffi::sqlite3_column_int64(stmt, col), 0)),
+            ffi::SQLITE_FLOAT => {
+                let mut jd = ffi::sqlite3_column_double(stmt, col);
+                jd -= JULIAN_DAY;
+                jd *= DAY_IN_SECONDS;
+                let ns = jd.fract() * 10f64.powi(9);
+                Ok(time::Timespec::new(jd as i64, ns as i32))
+            }
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
+        true // to avoid double check
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use Connection;
+    use super::time;
+
+    fn checked_memory_handle() -> Connection {
+        let db = Connection::open_in_memory().unwrap();
+        db.execute_batch("CREATE TABLE foo (t TEXT, i INTEGER, f FLOAT)").unwrap();
+        db
+    }
+
+    #[test]
+    fn test_timespec() {
+        let db = checked_memory_handle();
+
+        let ts = time::Timespec {
+            sec: 10_000,
+            nsec: 0,
+        };
+        db.execute("INSERT INTO foo(t, i) VALUES (?, ?)", &[&ts, &ts.sec]).unwrap();
+        db.execute("UPDATE foo SET f = julianday(t)", &[]).unwrap();
+
+        let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(from, ts);
+        let from: time::Timespec = db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(from, ts);
+        // `Timespec { sec: 9999, nsec: 999994039 }` vs `Timespec{ sec: 10000, nsec: 0 }`
+        let from: time::Timespec = db.query_row("SELECT f FROM foo", &[], |r| r.get(0)).unwrap();
+        assert!((from.sec - ts.sec).abs() <= 1);
+    }
+}

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -4,13 +4,9 @@ use libc::c_int;
 use {Error, Result};
 use types::{FromSql, ToSql};
 
-use ffi;
 use ffi::sqlite3_stmt;
-use ffi::sqlite3_column_type;
 
 const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
-const JULIAN_DAY: f64 = 2440587.5; // 1970-01-01 00:00:00 is JD 2440587.5
-const DAY_IN_SECONDS: f64 = 86400.0;
 
 impl ToSql for time::Timespec {
     unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
@@ -21,26 +17,15 @@ impl ToSql for time::Timespec {
 
 impl FromSql for time::Timespec {
     unsafe fn column_result(stmt: *mut sqlite3_stmt, col: c_int) -> Result<time::Timespec> {
-        match sqlite3_column_type(stmt, col) {
-            ffi::SQLITE_TEXT => {
-                let col_str = FromSql::column_result(stmt, col);
-                col_str.and_then(|txt: String| {
-                    match time::strptime(&txt, SQLITE_DATETIME_FMT) {
-                        Ok(tm) => Ok(tm.to_timespec()),
-                        Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
-                    }
-                })
-            }
-            ffi::SQLITE_INTEGER => Ok(time::Timespec::new(ffi::sqlite3_column_int64(stmt, col), 0)),
-            ffi::SQLITE_FLOAT => {
-                let mut jd = ffi::sqlite3_column_double(stmt, col);
-                jd -= JULIAN_DAY;
-                jd *= DAY_IN_SECONDS;
-                let ns = jd.fract() * 10f64.powi(9);
-                Ok(time::Timespec::new(jd as i64, ns as i32))
-            }
-            _ => Err(Error::InvalidColumnType),
+        let s = try!(String::column_result(stmt, col));
+        match time::strptime(&s, SQLITE_DATETIME_FMT) {
+            Ok(tm) => Ok(tm.to_timespec()),
+            Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
         }
+    }
+
+    unsafe fn column_has_valid_sqlite_type(stmt: *mut sqlite3_stmt, col: c_int) -> bool {
+        String::column_has_valid_sqlite_type(stmt, col)
     }
 }
 
@@ -63,15 +48,9 @@ mod test {
             sec: 10_000,
             nsec: 0,
         };
-        db.execute("INSERT INTO foo(t, i) VALUES (?, ?)", &[&ts, &ts.sec]).unwrap();
-        db.execute("UPDATE foo SET f = julianday(t)", &[]).unwrap();
+        db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts]).unwrap();
 
         let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(from, ts);
-        let from: time::Timespec = db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap();
-        assert_eq!(from, ts);
-        // `Timespec { sec: 9999, nsec: 999994039 }` vs `Timespec{ sec: 10000, nsec: 0 }`
-        let from: time::Timespec = db.query_row("SELECT f FROM foo", &[], |r| r.get(0)).unwrap();
-        assert!((from.sec - ts.sec).abs() <= 1);
     }
 }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -42,10 +42,6 @@ impl FromSql for time::Timespec {
             _ => Err(Error::InvalidColumnType),
         }
     }
-
-    unsafe fn column_has_valid_sqlite_type(_: *mut sqlite3_stmt, _: c_int) -> bool {
-        true // to avoid double check
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR cuts down #133 to the bare necessities:

* Removes support for storing dates and times as ints or floats (only supports strings)
* Prefers to use `chrono`'s RFC3339 functions when possible while still keeping support for SQLite's `datetime()` format

@gwenn This cuts out a lot of code and some significant functionality from #133. Do you think any of the things I cut out are critical to add back in?