### PR TITLE
Fix transaction lifetimes and nested savepoints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Version UPCOMING (...)
 
+* BREAKING CHANGE: Creating transactions from a `Connection` or savepoints from a `Transaction`
+  now take `&mut self` instead of `&self` to correctly represent that transactions within a
+  connection are inherently nested. While a transaction is alive, the parent connection or
+  transaction is unusable, so `Transaction` now implements `Deref<Target=Connection>`, giving
+  access to `Connection`'s methods via the `Transaction` itself.
 * Adds `insert` convenience method to `Statement` which returns the row ID of an inserted row.
 * Adds `exists` convenience method returning whether a query finds one or more rows.
 * Adds support for serializing types from the `serde_json` crate. Requires the `serde_json` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl Connection {
     /// # Failure
     ///
     /// Will return `Err` if the underlying SQLite call fails.
-    pub fn transaction(&self) -> Result<Transaction> {
+    pub fn transaction(&mut self) -> Result<Transaction> {
         Transaction::new(self, TransactionBehavior::Deferred)
     }
 
@@ -248,7 +248,7 @@ impl Connection {
     /// # Failure
     ///
     /// Will return `Err` if the underlying SQLite call fails.
-    pub fn transaction_with_behavior(&self, behavior: TransactionBehavior) -> Result<Transaction> {
+    pub fn transaction_with_behavior(&mut self, behavior: TransactionBehavior) -> Result<Transaction> {
         Transaction::new(self, behavior)
     }
 


### PR DESCRIPTION
Two changes in this PR:

* Breaking change: Transactions and savepoints are now created from a `&mut self`, correctly tying their nested nature to the Rust handle lifetimes.
* Bugfix: Nested savepoints now have distinct names.

Closes #142.