### PR TITLE
Address clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["SQLite", "lang_transaction"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -34,7 +34,7 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
     pub fn prepare_cached<'a>(&'a self, sql: &str) -> Result<CachedStatement<'a>> {
-        self.cache.get(&self, sql)
+        self.cache.get(self, sql)
     }
 
     /// Set the maximum number of cached prepared statements this connection will hold.

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,8 +160,8 @@ impl error::Error for Error {
             Error::InvalidColumnIndex(_) |
             Error::InvalidColumnName(_) |
             Error::InvalidColumnType |
-            Error::InvalidPath(_) => None,
-            Error::StatementChangedRows(_) => None,
+            Error::InvalidPath(_) |
+            Error::StatementChangedRows(_) |
             Error::StatementFailedToInsertRow => None,
 
             #[cfg(feature = "functions")]


### PR DESCRIPTION
After this PR, we have one clippy warning left:

```
src/lib.rs:996:5: 1015:6 warning: defining a method called `next` on this type; consider implementing the `std::iter::Iterator` trait or choosing a less ambiguous name, #[warn(should_implement_trait)] on by default
src/lib.rs:996     pub fn next<'a>(&'a mut self) -> Option<Result<Row<'a, 'stmt>>> {
                   ^
```

This one is caused by #153, and I think it's fine to keep it. `next()` looks like `Iterator` because I'd like it to be implementing `Iterator`, but we can't because of the lifetimes.