### PR TITLE
Redesign ToSql

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 * BREAKING CHANGE: The `FromSql` trait has been redesigned. It now requires a single, safe
   method instead of the previous definition which required implementing one or two unsafe
   methods.
+* BREAKING CHANGE: The `ToSql` trait has been redesigned. It can now be implemented without
+  `unsafe`, and implementors can choose to return either borrowed or owned results.
 
 # Version 0.7.2 (2016-05-19)
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -52,10 +52,9 @@ use std::io;
 use std::cmp::min;
 use std::mem;
 use std::ptr;
-use libc::c_int;
 
 use super::ffi;
-use super::types::ToSql;
+use super::types::{ToSql, ToSqlOutput};
 use {Result, Connection, DatabaseName};
 
 /// Handle to an open BLOB.
@@ -244,9 +243,9 @@ impl<'conn> Drop for Blob<'conn> {
 pub struct ZeroBlob(pub i32);
 
 impl ToSql for ZeroBlob {
-    unsafe fn bind_parameter(&self, stmt: *mut ffi::sqlite3_stmt, col: c_int) -> c_int {
+    fn to_sql(&self) -> Result<ToSqlOutput> {
         let ZeroBlob(length) = *self;
-        ffi::sqlite3_bind_zeroblob(stmt, col, length)
+        Ok(ToSqlOutput::ZeroBlob(length))
     }
 }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -106,7 +106,10 @@ fn set_result<'a>(ctx: *mut sqlite3_context, result: &ToSqlOutput<'a>) {
             } else if length == 0 {
                 ffi::sqlite3_result_zeroblob(ctx, 0)
             } else {
-                ffi::sqlite3_result_blob(ctx, b.as_ptr() as *const c_void, length as c_int, ffi::SQLITE_TRANSIENT());
+                ffi::sqlite3_result_blob(ctx,
+                                         b.as_ptr() as *const c_void,
+                                         length as c_int,
+                                         ffi::SQLITE_TRANSIENT());
             }
         },
     }
@@ -139,7 +142,8 @@ impl<'a> ValueRef<'a> {
             ffi::SQLITE_FLOAT => ValueRef::Real(ffi::sqlite3_value_double(value)),
             ffi::SQLITE_TEXT => {
                 let text = ffi::sqlite3_value_text(value);
-                assert!(!text.is_null(), "unexpected SQLITE_TEXT value type with NULL data");
+                assert!(!text.is_null(),
+                        "unexpected SQLITE_TEXT value type with NULL data");
                 let s = CStr::from_ptr(text as *const c_char);
 
                 // sqlite3_value_text returns UTF8 data, so our unwrap here should be fine.
@@ -148,10 +152,12 @@ impl<'a> ValueRef<'a> {
             }
             ffi::SQLITE_BLOB => {
                 let blob = ffi::sqlite3_value_blob(value);
-                assert!(!blob.is_null(), "unexpected SQLITE_BLOB value type with NULL data");
+                assert!(!blob.is_null(),
+                        "unexpected SQLITE_BLOB value type with NULL data");
 
                 let len = ffi::sqlite3_value_bytes(value);
-                assert!(len >= 0, "unexpected negative return from sqlite3_value_bytes");
+                assert!(len >= 0,
+                        "unexpected negative return from sqlite3_value_bytes");
 
                 ValueRef::Blob(from_raw_parts(blob as *const u8, len as usize))
             }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -57,10 +57,10 @@ use std::slice;
 use libc::{c_int, c_char, c_void};
 
 use ffi;
-pub use ffi::sqlite3_context;
-pub use ffi::sqlite3_value;
-pub use ffi::sqlite3_value_type;
-pub use ffi::sqlite3_value_numeric_type;
+use ffi::sqlite3_context;
+use ffi::sqlite3_value;
+use ffi::sqlite3_value_type;
+use ffi::sqlite3_value_numeric_type;
 
 use types::{ToSql, ToSqlOutput, FromSql, ValueRef};
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -54,7 +54,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::slice;
-use libc::{c_int, c_double, c_char, c_void};
+use libc::{c_int, c_char, c_void};
 
 use ffi;
 pub use ffi::sqlite3_context;
@@ -62,97 +62,70 @@ pub use ffi::sqlite3_value;
 pub use ffi::sqlite3_value_type;
 pub use ffi::sqlite3_value_numeric_type;
 
-use types::{Null, FromSql, ValueRef};
+use types::{ToSql, ToSqlOutput, FromSql, ValueRef};
 
 use {Result, Error, Connection, str_to_cstring, InnerConnection};
 
-/// A trait for types that can be converted into the result of an SQL function.
-pub trait ToResult {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context);
+fn set_result<'a>(ctx: *mut sqlite3_context, result: &ToSqlOutput<'a>) {
+    let value = match *result {
+        ToSqlOutput::Borrowed(v) => v,
+        ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+
+        #[cfg(feature = "blob")]
+        ToSqlOutput::ZeroBlob(len) => {
+            return unsafe { ffi::sqlite3_result_zeroblob(ctx, len) };
+        }
+    };
+
+    match value {
+        ValueRef::Null => unsafe { ffi::sqlite3_result_null(ctx) },
+        ValueRef::Integer(i) => unsafe { ffi::sqlite3_result_int64(ctx, i) },
+        ValueRef::Real(r) => unsafe { ffi::sqlite3_result_double(ctx, r) },
+        ValueRef::Text(ref s) => unsafe {
+            let length = s.len();
+            if length > ::std::i32::MAX as usize {
+                ffi::sqlite3_result_error_toobig(ctx);
+            } else {
+                let c_str = match str_to_cstring(s) {
+                    Ok(c_str) => c_str,
+                    // TODO sqlite3_result_error
+                    Err(_) => return ffi::sqlite3_result_error_code(ctx, ffi::SQLITE_MISUSE),
+                };
+                let destructor = if length > 0 {
+                    ffi::SQLITE_TRANSIENT()
+                } else {
+                    ffi::SQLITE_STATIC()
+                };
+                ffi::sqlite3_result_text(ctx, c_str.as_ptr(), length as c_int, destructor);
+            }
+        },
+        ValueRef::Blob(ref b) => unsafe {
+            let length = b.len();
+            if length > ::std::i32::MAX as usize {
+                ffi::sqlite3_result_error_toobig(ctx);
+            } else if length == 0 {
+                ffi::sqlite3_result_zeroblob(ctx, 0)
+            } else {
+                ffi::sqlite3_result_blob(ctx, b.as_ptr() as *const c_void, length as c_int, ffi::SQLITE_TRANSIENT());
+            }
+        },
+    }
 }
 
-macro_rules! raw_to_impl(
-    ($t:ty, $f:ident) => (
-        impl ToResult for $t {
-            unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-                ffi::$f(ctx, *self)
+unsafe fn report_error(ctx: *mut sqlite3_context, err: &Error) {
+    match err {
+        &Error::SqliteFailure(ref err, ref s) => {
+            ffi::sqlite3_result_error_code(ctx, err.extended_code);
+            if let Some(Ok(cstr)) = s.as_ref().map(|s| str_to_cstring(s)) {
+                ffi::sqlite3_result_error(ctx, cstr.as_ptr(), -1);
             }
         }
-    )
-);
-
-raw_to_impl!(c_int, sqlite3_result_int);
-raw_to_impl!(i64, sqlite3_result_int64);
-raw_to_impl!(c_double, sqlite3_result_double);
-
-impl<'a> ToResult for bool {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        if *self {
-            ffi::sqlite3_result_int(ctx, 1)
-        } else {
-            ffi::sqlite3_result_int(ctx, 0)
-        }
-    }
-}
-
-
-impl<'a> ToResult for &'a str {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        let length = self.len();
-        if length > ::std::i32::MAX as usize {
-            ffi::sqlite3_result_error_toobig(ctx);
-            return;
-        }
-        match str_to_cstring(self) {
-            Ok(c_str) => {
-                ffi::sqlite3_result_text(ctx,
-                                         c_str.as_ptr(),
-                                         length as c_int,
-                                         ffi::SQLITE_TRANSIENT())
+        _ => {
+            ffi::sqlite3_result_error_code(ctx, ffi::SQLITE_CONSTRAINT_FUNCTION);
+            if let Ok(cstr) = str_to_cstring(err.description()) {
+                ffi::sqlite3_result_error(ctx, cstr.as_ptr(), -1);
             }
-            // TODO sqlite3_result_error
-            Err(_) => ffi::sqlite3_result_error_code(ctx, ffi::SQLITE_MISUSE),
         }
-    }
-}
-
-impl ToResult for String {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        (&self[..]).set_result(ctx)
-    }
-}
-
-impl<'a> ToResult for &'a [u8] {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        if self.len() > ::std::i32::MAX as usize {
-            ffi::sqlite3_result_error_toobig(ctx);
-            return;
-        }
-        ffi::sqlite3_result_blob(ctx,
-                                 mem::transmute(self.as_ptr()),
-                                 self.len() as c_int,
-                                 ffi::SQLITE_TRANSIENT())
-    }
-}
-
-impl ToResult for Vec<u8> {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        (&self[..]).set_result(ctx)
-    }
-}
-
-impl<T: ToResult> ToResult for Option<T> {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        match *self {
-            None => ffi::sqlite3_result_null(ctx),
-            Some(ref t) => t.set_result(ctx),
-        }
-    }
-}
-
-impl ToResult for Null {
-    unsafe fn set_result(&self, ctx: *mut sqlite3_context) {
-        ffi::sqlite3_result_null(ctx)
     }
 }
 
@@ -259,7 +232,7 @@ impl<'a> Context<'a> {
 /// `A` is the type of the aggregation context and `T` is the type of the final result.
 /// Implementations should be stateless.
 pub trait Aggregate<A, T>
-    where T: ToResult
+    where T: ToSql
 {
     /// Initializes the aggregation context. Will be called prior to the first call
     /// to `step()` to set up the context for an invocation of the function. (Note:
@@ -316,7 +289,7 @@ impl Connection {
                                         x_func: F)
                                         -> Result<()>
         where F: FnMut(&Context) -> Result<T>,
-              T: ToResult
+              T: ToSql
     {
         self.db.borrow_mut().create_scalar_function(fn_name, n_arg, deterministic, x_func)
     }
@@ -333,7 +306,7 @@ impl Connection {
                                               aggr: D)
                                               -> Result<()>
         where D: Aggregate<A, T>,
-              T: ToResult
+              T: ToSql
     {
         self.db
             .borrow_mut()
@@ -361,13 +334,13 @@ impl InnerConnection {
                                     x_func: F)
                                     -> Result<()>
         where F: FnMut(&Context) -> Result<T>,
-              T: ToResult
+              T: ToSql
     {
         unsafe extern "C" fn call_boxed_closure<F, T>(ctx: *mut sqlite3_context,
                                                       argc: c_int,
                                                       argv: *mut *mut sqlite3_value)
             where F: FnMut(&Context) -> Result<T>,
-                  T: ToResult
+                  T: ToSql
         {
             let ctx = Context {
                 ctx: ctx,
@@ -375,20 +348,14 @@ impl InnerConnection {
             };
             let boxed_f: *mut F = mem::transmute(ffi::sqlite3_user_data(ctx.ctx));
             assert!(!boxed_f.is_null(), "Internal error - null function pointer");
-            match (*boxed_f)(&ctx) {
-                Ok(r) => r.set_result(ctx.ctx),
-                Err(Error::SqliteFailure(err, s)) => {
-                    ffi::sqlite3_result_error_code(ctx.ctx, err.extended_code);
-                    if let Some(Ok(cstr)) = s.map(|s| str_to_cstring(&s)) {
-                        ffi::sqlite3_result_error(ctx.ctx, cstr.as_ptr(), -1);
-                    }
-                }
-                Err(err) => {
-                    ffi::sqlite3_result_error_code(ctx.ctx, ffi::SQLITE_CONSTRAINT_FUNCTION);
-                    if let Ok(cstr) = str_to_cstring(err.description()) {
-                        ffi::sqlite3_result_error(ctx.ctx, cstr.as_ptr(), -1);
-                    }
-                }
+
+            let t = (*boxed_f)(&ctx);
+            let t = t.as_ref().map(|t| ToSql::to_sql(t));
+
+            match t {
+                Ok(Ok(ref value)) => set_result(ctx.ctx, value),
+                Ok(Err(err)) => report_error(ctx.ctx, &err),
+                Err(err) => report_error(ctx.ctx, err),
             }
         }
 
@@ -419,7 +386,7 @@ impl InnerConnection {
                                           aggr: D)
                                           -> Result<()>
         where D: Aggregate<A, T>,
-              T: ToResult
+              T: ToSql
     {
         unsafe fn aggregate_context<A>(ctx: *mut sqlite3_context,
                                        bytes: usize)
@@ -431,28 +398,11 @@ impl InnerConnection {
             Some(pac)
         }
 
-        unsafe fn report_aggregate_error(ctx: *mut sqlite3_context, err: Error) {
-            match err {
-                Error::SqliteFailure(err, s) => {
-                    ffi::sqlite3_result_error_code(ctx, err.extended_code);
-                    if let Some(Ok(cstr)) = s.map(|s| str_to_cstring(&s)) {
-                        ffi::sqlite3_result_error(ctx, cstr.as_ptr(), -1);
-                    }
-                }
-                _ => {
-                    ffi::sqlite3_result_error_code(ctx, ffi::SQLITE_CONSTRAINT_FUNCTION);
-                    if let Ok(cstr) = str_to_cstring(err.description()) {
-                        ffi::sqlite3_result_error(ctx, cstr.as_ptr(), -1);
-                    }
-                }
-            }
-        }
-
         unsafe extern "C" fn call_boxed_step<A, D, T>(ctx: *mut sqlite3_context,
                                                       argc: c_int,
                                                       argv: *mut *mut sqlite3_value)
             where D: Aggregate<A, T>,
-                  T: ToResult
+                  T: ToSql
         {
             let boxed_aggr: *mut D = mem::transmute(ffi::sqlite3_user_data(ctx));
             assert!(!boxed_aggr.is_null(),
@@ -477,13 +427,13 @@ impl InnerConnection {
 
             match (*boxed_aggr).step(&mut ctx, &mut **pac) {
                 Ok(_) => {}
-                Err(err) => report_aggregate_error(ctx.ctx, err),
+                Err(err) => report_error(ctx.ctx, &err),
             };
         }
 
         unsafe extern "C" fn call_boxed_final<A, D, T>(ctx: *mut sqlite3_context)
             where D: Aggregate<A, T>,
-                  T: ToResult
+                  T: ToSql
         {
             let boxed_aggr: *mut D = mem::transmute(ffi::sqlite3_user_data(ctx));
             assert!(!boxed_aggr.is_null(),
@@ -503,10 +453,13 @@ impl InnerConnection {
                 None => None,
             };
 
-            match (*boxed_aggr).finalize(a) {
-                Ok(r) => r.set_result(ctx),
-                Err(err) => report_aggregate_error(ctx, err),
-            };
+            let t = (*boxed_aggr).finalize(a);
+            let t = t.as_ref().map(|t| ToSql::to_sql(t));
+            match t {
+                Ok(Ok(ref value)) => set_result(ctx, value),
+                Ok(Err(err)) => report_error(ctx, &err),
+                Err(err) => report_error(ctx, err),
+            }
         }
 
         let boxed_aggr: *mut D = Box::into_raw(Box::new(aggr));

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -182,7 +182,7 @@ impl<'a> ValueRef<'a> {
 
                 ValueRef::Blob(from_raw_parts(blob as *const u8, len as usize))
             }
-            _ => unreachable!("sqlite3_value_type returned invalid value")
+            _ => unreachable!("sqlite3_value_type returned invalid value"),
         }
     }
 }
@@ -219,7 +219,7 @@ impl<'a> Context<'a> {
         let value = unsafe { ValueRef::from_value(arg) };
         FromSql::column_result(value).map_err(|err| match err {
             Error::InvalidColumnType => Error::InvalidFunctionParameterType,
-            _ => err
+            _ => err,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,11 +878,7 @@ impl<'conn> Statement<'conn> {
     }
 
     fn bind_parameter(&self, param: &ToSql, col: c_int) -> Result<()> {
-        // This should be
-        //   let value = try!(param.to_sql());
-        // but that hits a bug in the Rust compiler around re-exported
-        // trait visibility. It's fixed in 1.9.
-        let value = try!(ToSql::to_sql(param));
+        let value = try!(param.to_sql());
 
         let ptr = unsafe { self.stmt.ptr() };
         let value = match value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,7 +888,8 @@ impl<'conn> Statement<'conn> {
 
             #[cfg(feature = "blob")]
             ToSqlOutput::ZeroBlob(len) => {
-                return self.conn.decode_result(unsafe { ffi::sqlite3_bind_zeroblob(ptr, col, len) });
+                return self.conn
+                    .decode_result(unsafe { ffi::sqlite3_bind_zeroblob(ptr, col, len) });
             }
         };
         self.conn.decode_result(match value {
@@ -916,7 +917,11 @@ impl<'conn> Statement<'conn> {
                 } else if length == 0 {
                     ffi::sqlite3_bind_zeroblob(ptr, col, 0)
                 } else {
-                    ffi::sqlite3_bind_blob(ptr, col, b.as_ptr() as *const c_void, length as c_int, ffi::SQLITE_TRANSIENT())
+                    ffi::sqlite3_bind_blob(ptr,
+                                           col,
+                                           b.as_ptr() as *const c_void,
+                                           length as c_int,
+                                           ffi::SQLITE_TRANSIENT())
                 }
             },
         })
@@ -1153,7 +1158,8 @@ impl<'a> ValueRef<'a> {
             ffi::SQLITE_FLOAT => ValueRef::Real(ffi::sqlite3_column_double(raw, col)),
             ffi::SQLITE_TEXT => {
                 let text = ffi::sqlite3_column_text(raw, col);
-                assert!(!text.is_null(), "unexpected SQLITE_TEXT column type with NULL data");
+                assert!(!text.is_null(),
+                        "unexpected SQLITE_TEXT column type with NULL data");
                 let s = CStr::from_ptr(text as *const c_char);
 
                 // sqlite3_column_text returns UTF8 data, so our unwrap here should be fine.
@@ -1162,10 +1168,12 @@ impl<'a> ValueRef<'a> {
             }
             ffi::SQLITE_BLOB => {
                 let blob = ffi::sqlite3_column_blob(raw, col);
-                assert!(!blob.is_null(), "unexpected SQLITE_BLOB column type with NULL data");
+                assert!(!blob.is_null(),
+                        "unexpected SQLITE_BLOB column type with NULL data");
 
                 let len = ffi::sqlite3_column_bytes(raw, col);
-                assert!(len >= 0, "unexpected negative return from sqlite3_column_bytes");
+                assert!(len >= 0,
+                        "unexpected negative return from sqlite3_column_bytes");
 
                 ValueRef::Blob(from_raw_parts(blob as *const u8, len as usize))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,9 @@ use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::result;
 use std::str;
-use libc::{c_int, c_char};
+use libc::{c_int, c_char, c_void};
 
-use types::{ToSql, FromSql, ValueRef};
+use types::{ToSql, ToSqlOutput, FromSql, ValueRef};
 use error::{error_from_sqlite_code, error_from_handle};
 use raw_statement::RawStatement;
 use cache::StatementCache;
@@ -874,6 +874,54 @@ impl<'conn> Statement<'conn> {
         self.finalize_()
     }
 
+    fn bind_parameter(&self, param: &ToSql, col: c_int) -> Result<()> {
+        // This should be
+        //   let value = try!(param.to_sql());
+        // but that hits a bug in the Rust compiler around re-exported
+        // trait visibility. It's fixed in 1.9.
+        let value = try!(ToSql::to_sql(param));
+
+        let ptr = unsafe { self.stmt.ptr() };
+        let value = match value {
+            ToSqlOutput::Borrowed(v) => v,
+            ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+
+            #[cfg(feature = "blob")]
+            ToSqlOutput::ZeroBlob(len) => {
+                return self.conn.decode_result(unsafe { ffi::sqlite3_bind_zeroblob(ptr, col, len) });
+            }
+        };
+        self.conn.decode_result(match value {
+            ValueRef::Null => unsafe { ffi::sqlite3_bind_null(ptr, col) },
+            ValueRef::Integer(i) => unsafe { ffi::sqlite3_bind_int64(ptr, col, i) },
+            ValueRef::Real(r) => unsafe { ffi::sqlite3_bind_double(ptr, col, r) },
+            ValueRef::Text(ref s) => unsafe {
+                let length = s.len();
+                if length > ::std::i32::MAX as usize {
+                    ffi::SQLITE_TOOBIG
+                } else {
+                    let c_str = try!(str_to_cstring(s));
+                    let destructor = if length > 0 {
+                        ffi::SQLITE_TRANSIENT()
+                    } else {
+                        ffi::SQLITE_STATIC()
+                    };
+                    ffi::sqlite3_bind_text(ptr, col, c_str.as_ptr(), length as c_int, destructor)
+                }
+            },
+            ValueRef::Blob(ref b) => unsafe {
+                let length = b.len();
+                if length > ::std::i32::MAX as usize {
+                    ffi::SQLITE_TOOBIG
+                } else if length == 0 {
+                    ffi::sqlite3_bind_zeroblob(ptr, col, 0)
+                } else {
+                    ffi::sqlite3_bind_blob(ptr, col, b.as_ptr() as *const c_void, length as c_int, ffi::SQLITE_TRANSIENT())
+                }
+            },
+        })
+    }
+
     fn bind_parameters(&mut self, params: &[&ToSql]) -> Result<()> {
         assert!(params.len() as c_int == self.stmt.bind_parameter_count(),
                 "incorrect number of parameters to query(): expected {}, got {}",
@@ -881,14 +929,7 @@ impl<'conn> Statement<'conn> {
                 params.len());
 
         for (i, p) in params.iter().enumerate() {
-            try!(unsafe {
-                self.conn.decode_result(
-                    // This should be
-                    // `p.bind_parameter(self.stmt.ptr(), (i + 1) as c_int)`
-                    // but that doesn't compile until Rust 1.9 due to a compiler bug.
-                    ToSql::bind_parameter(*p, self.stmt.ptr(), (i + 1) as c_int)
-                )
-            });
+            try!(self.bind_parameter(*p, (i + 1) as c_int));
         }
 
         Ok(())
@@ -1128,7 +1169,7 @@ impl<'a> ValueRef<'a> {
 
                 ValueRef::Blob(from_raw_parts(blob as *const u8, len as usize))
             }
-            _ => unreachable!("sqlite3_column_type returned invalid value")
+            _ => unreachable!("sqlite3_column_type returned invalid value"),
         }
     }
 }

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -204,12 +204,7 @@ impl<'conn> Statement<'conn> {
     fn bind_parameters_named(&mut self, params: &[(&str, &ToSql)]) -> Result<()> {
         for &(name, value) in params {
             if let Some(i) = try!(self.parameter_index(name)) {
-                try!(self.conn.decode_result(unsafe {
-                    // This should be
-                    // `value.bind_parameter(self.stmt.ptr(), i)`
-                    // but that doesn't compile until Rust 1.9 due to a compiler bug.
-                    ToSql::bind_parameter(value, self.stmt.ptr(), i)
-                }));
+                try!(self.bind_parameter(value, i));
             } else {
                 return Err(Error::InvalidParameterName(name.into()));
             }

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -4,18 +4,15 @@ extern crate chrono;
 use std::borrow::Cow;
 
 use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, UTC, Local};
-use libc::c_int;
 
 use {Error, Result};
-use types::{FromSql, ToSql, ValueRef};
-
-use ffi::sqlite3_stmt;
+use types::{FromSql, ToSql, ToSqlOutput, ValueRef};
 
 /// ISO 8601 calendar date without timezone => "YYYY-MM-DD"
 impl ToSql for NaiveDate {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+    fn to_sql(&self) -> Result<ToSqlOutput> {
         let date_str = self.format("%Y-%m-%d").to_string();
-        date_str.bind_parameter(stmt, col)
+        Ok(ToSqlOutput::from(date_str))
     }
 }
 
@@ -31,9 +28,9 @@ impl FromSql for NaiveDate {
 
 /// ISO 8601 time without timezone => "HH:MM:SS.SSS"
 impl ToSql for NaiveTime {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+    fn to_sql(&self) -> Result<ToSqlOutput> {
         let date_str = self.format("%H:%M:%S%.f").to_string();
-        date_str.bind_parameter(stmt, col)
+        Ok(ToSqlOutput::from(date_str))
     }
 }
 
@@ -56,9 +53,9 @@ impl FromSql for NaiveTime {
 
 /// ISO 8601 combined date and time without timezone => "YYYY-MM-DD HH:MM:SS.SSS"
 impl ToSql for NaiveDateTime {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+    fn to_sql(&self) -> Result<ToSqlOutput> {
         let date_str = self.format("%Y-%m-%dT%H:%M:%S%.f").to_string();
-        date_str.bind_parameter(stmt, col)
+        Ok(ToSqlOutput::from(date_str))
     }
 }
 
@@ -83,9 +80,8 @@ impl FromSql for NaiveDateTime {
 
 /// Date and time with time zone => UTC RFC3339 timestamp ("YYYY-MM-DDTHH:MM:SS.SSS+00:00").
 impl<Tz: TimeZone> ToSql for DateTime<Tz> {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
-        let utc_dt = self.with_timezone(&UTC);
-        utc_dt.to_rfc3339().bind_parameter(stmt, col)
+    fn to_sql(&self) -> Result<ToSqlOutput> {
+        Ok(ToSqlOutput::from(self.with_timezone(&UTC).to_rfc3339()))
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -52,8 +52,10 @@
 
 pub use self::from_sql::FromSql;
 pub use self::to_sql::{ToSql, ToSqlOutput};
+pub use self::value::Value;
 pub use self::value_ref::ValueRef;
 
+mod value;
 mod value_ref;
 mod from_sql;
 mod to_sql;
@@ -81,60 +83,6 @@ mod serde_json;
 /// ```
 #[derive(Copy,Clone)]
 pub struct Null;
-
-/// Owning [dynamic type value](http://sqlite.org/datatype3.html). Value's type is typically
-/// dictated by SQLite (not by the caller).
-///
-/// See [`ValueRef`](enum.ValueRef.html) for a non-owning dynamic type value.
-#[derive(Clone,Debug,PartialEq)]
-pub enum Value {
-    /// The value is a `NULL` value.
-    Null,
-    /// The value is a signed integer.
-    Integer(i64),
-    /// The value is a floating point number.
-    Real(f64),
-    /// The value is a text string.
-    Text(String),
-    /// The value is a blob of data
-    Blob(Vec<u8>),
-}
-
-impl From<Null> for Value {
-    fn from(_: Null) -> Value {
-        Value::Null
-    }
-}
-
-impl From<i32> for Value {
-    fn from(i: i32) -> Value {
-        Value::Integer(i as i64)
-    }
-}
-
-impl From<i64> for Value {
-    fn from(i: i64) -> Value {
-        Value::Integer(i)
-    }
-}
-
-impl From<f64> for Value {
-    fn from(f: f64) -> Value {
-        Value::Real(f)
-    }
-}
-
-impl From<String> for Value {
-    fn from(s: String) -> Value {
-        Value::Text(s)
-    }
-}
-
-impl From<Vec<u8>> for Value {
-    fn from(v: Vec<u8>) -> Value {
-        Value::Blob(v)
-    }
-}
 
 #[cfg(test)]
 #[cfg_attr(feature="clippy", allow(similar_names))]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -50,10 +50,8 @@
 //! `FromSql` for the cases where you want to know if a value was NULL (which gets translated to
 //! `None`).
 
-pub use ffi::sqlite3_stmt;
-
 pub use self::from_sql::FromSql;
-pub use self::to_sql::ToSql;
+pub use self::to_sql::{ToSql, ToSqlOutput};
 pub use self::value_ref::ValueRef;
 
 mod value_ref;
@@ -102,6 +100,42 @@ pub enum Value {
     Blob(Vec<u8>),
 }
 
+impl From<Null> for Value {
+    fn from(_: Null) -> Value {
+        Value::Null
+    }
+}
+
+impl From<i32> for Value {
+    fn from(i: i32) -> Value {
+        Value::Integer(i as i64)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(i: i64) -> Value {
+        Value::Integer(i)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(f: f64) -> Value {
+        Value::Real(f)
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Value {
+        Value::Text(s)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(v: Vec<u8>) -> Value {
+        Value::Blob(v)
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(feature="clippy", allow(similar_names))]
 mod test {
@@ -111,6 +145,7 @@ mod test {
     use Error;
     use libc::{c_int, c_double};
     use std::f64::EPSILON;
+    use super::Value;
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -134,10 +169,30 @@ mod test {
         let db = checked_memory_handle();
 
         let s = "hello, world!";
+        db.execute("INSERT INTO foo(t) VALUES (?)", &[&s]).unwrap();
+
+        let from: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
+        assert_eq!(from, s);
+    }
+
+    #[test]
+    fn test_string() {
+        let db = checked_memory_handle();
+
+        let s = "hello, world!";
         db.execute("INSERT INTO foo(t) VALUES (?)", &[&s.to_owned()]).unwrap();
 
         let from: String = db.query_row("SELECT t FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(from, s);
+    }
+
+    #[test]
+    fn test_value() {
+        let db = checked_memory_handle();
+
+        db.execute("INSERT INTO foo(i) VALUES (?)", &[&Value::Integer(10)]).unwrap();
+
+        assert_eq!(10i64, db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap());
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -140,7 +140,8 @@ mod test {
 
         db.execute("INSERT INTO foo(i) VALUES (?)", &[&Value::Integer(10)]).unwrap();
 
-        assert_eq!(10i64, db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap());
+        assert_eq!(10i64,
+                   db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap());
     }
 
     #[test]

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,17 +1,14 @@
 extern crate time;
 
-use libc::c_int;
 use {Error, Result};
-use types::{FromSql, ToSql, ValueRef};
-
-use ffi::sqlite3_stmt;
+use types::{FromSql, ToSql, ToSqlOutput, ValueRef};
 
 const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
 
 impl ToSql for time::Timespec {
-    unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
-        let time_str = time::at_utc(*self).strftime(SQLITE_DATETIME_FMT).unwrap().to_string();
-        time_str.bind_parameter(stmt, col)
+    fn to_sql(&self) -> Result<ToSqlOutput> {
+        let time_string = time::at_utc(*self).strftime(SQLITE_DATETIME_FMT).unwrap().to_string();
+        Ok(ToSqlOutput::from(time_string))
     }
 }
 

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -1,7 +1,7 @@
 use super::{Null, Value, ValueRef};
 use ::Result;
 
-/// ToSqlOutput represents the possible output types for implementors of the ToSql trait.
+/// `ToSqlOutput` represents the possible output types for implementors of the `ToSql` trait.
 pub enum ToSqlOutput<'a> {
     /// A borrowed SQLite-representable value.
     Borrowed(ValueRef<'a>),

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -49,6 +49,7 @@ macro_rules! to_sql_self(
 );
 
 to_sql_self!(Null);
+to_sql_self!(bool);
 to_sql_self!(i32);
 to_sql_self!(i64);
 to_sql_self!(f64);

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -14,7 +14,9 @@ pub enum ToSqlOutput<'a> {
     ZeroBlob(i32),
 }
 
-impl<'a, T: ?Sized> From<&'a T> for ToSqlOutput<'a> where &'a T: Into<ValueRef<'a>> {
+impl<'a, T: ?Sized> From<&'a T> for ToSqlOutput<'a>
+    where &'a T: Into<ValueRef<'a>>
+{
     fn from(t: &'a T) -> Self {
         ToSqlOutput::Borrowed(t.into())
     }
@@ -59,7 +61,9 @@ to_sql_self!(i32);
 to_sql_self!(i64);
 to_sql_self!(f64);
 
-impl<'a, T: ?Sized> ToSql for &'a T where &'a T: Into<ToSqlOutput<'a>> {
+impl<'a, T: ?Sized> ToSql for &'a T
+    where &'a T: Into<ToSqlOutput<'a>>
+{
     fn to_sql(&self) -> Result<ToSqlOutput> {
         Ok(ToSqlOutput::from((*self).into()))
     }

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -1,10 +1,15 @@
 use super::{Null, Value, ValueRef};
 use ::Result;
 
+/// ToSqlOutput represents the possible output types for implementors of the ToSql trait.
 pub enum ToSqlOutput<'a> {
+    /// A borrowed SQLite-representable value.
     Borrowed(ValueRef<'a>),
+
+    /// An owned SQLite-representable value.
     Owned(Value),
 
+    /// A BLOB of the given length that is filled with zeroes.
     #[cfg(feature = "blob")]
     ZeroBlob(i32),
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -24,6 +24,12 @@ impl From<Null> for Value {
     }
 }
 
+impl From<bool> for Value {
+    fn from(i: bool) -> Value {
+        Value::Integer(i as i64)
+    }
+}
+
 impl From<i32> for Value {
     fn from(i: i32) -> Value {
         Value::Integer(i as i64)

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,0 +1,55 @@
+use super::Null;
+
+/// Owning [dynamic type value](http://sqlite.org/datatype3.html). Value's type is typically
+/// dictated by SQLite (not by the caller).
+///
+/// See [`ValueRef`](enum.ValueRef.html) for a non-owning dynamic type value.
+#[derive(Clone,Debug,PartialEq)]
+pub enum Value {
+    /// The value is a `NULL` value.
+    Null,
+    /// The value is a signed integer.
+    Integer(i64),
+    /// The value is a floating point number.
+    Real(f64),
+    /// The value is a text string.
+    Text(String),
+    /// The value is a blob of data
+    Blob(Vec<u8>),
+}
+
+impl From<Null> for Value {
+    fn from(_: Null) -> Value {
+        Value::Null
+    }
+}
+
+impl From<i32> for Value {
+    fn from(i: i32) -> Value {
+        Value::Integer(i as i64)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(i: i64) -> Value {
+        Value::Integer(i)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(f: f64) -> Value {
+        Value::Real(f)
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Value {
+        Value::Text(s)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(v: Vec<u8>) -> Value {
+        Value::Blob(v)
+    }
+}

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -70,6 +70,18 @@ impl<'a> From<ValueRef<'a>> for Value {
     }
 }
 
+impl<'a> From<&'a str> for ValueRef<'a> {
+    fn from(s: &str) -> ValueRef {
+        ValueRef::Text(s)
+    }
+}
+
+impl<'a> From<&'a [u8]> for ValueRef<'a> {
+    fn from(s: &[u8]) -> ValueRef {
+        ValueRef::Blob(s)
+    }
+}
+
 impl<'a> From<&'a Value> for ValueRef<'a> {
     fn from(value: &'a Value) -> ValueRef<'a> {
         match *value {


### PR DESCRIPTION
Closes #162.

This does not address the possibility of allowing binds of text or blobs without `SQLITE_TRANSIENT`, but does remove the need to use `unsafe` to implement `ToSql`.
