### PR TITLE
Use new Rust 1.9 attribute: #[deprecated(since = "...", note = "...")]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 * BREAKING CHANGE: The `FromSql` trait has been redesigned. It now requires a single, safe
   method instead of the previous definition which required implementing one or two unsafe
   methods.
+* Added `#[deprecated(since = "...", note = "...")]` flags (new in Rust 1.9 for libraries) to
+  all deprecated APIs.
 
 # Version 0.7.2 (2016-05-19)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  TARGET: 1.8.0-x86_64-pc-windows-gnu
+  TARGET: 1.9.0-x86_64-pc-windows-gnu
   MSYS2_BITS: 64
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe"

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use libc::c_int;
 use {ffi, errmsg_to_string};
 
 /// Old name for `Error`. `SqliteError` is deprecated.
+#[deprecated]
 pub type SqliteError = Error;
 
 /// Enum listing possible errors from rusqlite.

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use libc::c_int;
 use {ffi, errmsg_to_string};
 
 /// Old name for `Error`. `SqliteError` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Error instead")]
 pub type SqliteError = Error;
 
 /// Enum listing possible errors from rusqlite.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod raw_statement;
 const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 
 /// Old name for `Result`. `SqliteResult` is deprecated.
+#[deprecated]
 pub type SqliteResult<T> = Result<T>;
 
 /// A typedef of the result returned by many methods.
@@ -151,6 +152,7 @@ impl<'a> DatabaseName<'a> {
 }
 
 /// Old name for `Connection`. `SqliteConnection` is deprecated.
+#[deprecated]
 pub type SqliteConnection = Connection;
 
 /// A connection to a SQLite database.
@@ -367,6 +369,7 @@ impl Connection {
     ///
     /// This method should be considered deprecated. Use `query_row` instead, which now
     /// does exactly the same thing.
+    #[deprecated]
     pub fn query_row_safe<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
         where F: FnOnce(Row) -> T
     {
@@ -507,6 +510,7 @@ struct InnerConnection {
 }
 
 /// Old name for `OpenFlags`. `SqliteOpenFlags` is deprecated.
+#[deprecated]
 pub type SqliteOpenFlags = OpenFlags;
 
 bitflags! {
@@ -678,6 +682,7 @@ impl Drop for InnerConnection {
 }
 
 /// Old name for `Statement`. `SqliteStatement` is deprecated.
+#[deprecated]
 pub type SqliteStatement<'conn> = Statement<'conn>;
 
 /// A prepared statement.
@@ -967,6 +972,7 @@ impl<'stmt, T, E, F> Iterator for AndThenRows<'stmt, F>
 }
 
 /// Old name for `Rows`. `SqliteRows` is deprecated.
+#[deprecated]
 pub type SqliteRows<'stmt> = Rows<'stmt>;
 
 /// An handle for the resulting rows of a query.
@@ -1031,6 +1037,7 @@ impl<'stmt> Drop for Rows<'stmt> {
 }
 
 /// Old name for `Row`. `SqliteRow` is deprecated.
+#[deprecated]
 pub type SqliteRow<'a, 'stmt> = Row<'a, 'stmt>;
 
 /// A single result row of a query.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod raw_statement;
 const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 
 /// Old name for `Result`. `SqliteResult` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Result instead")]
 pub type SqliteResult<T> = Result<T>;
 
 /// A typedef of the result returned by many methods.
@@ -152,7 +152,7 @@ impl<'a> DatabaseName<'a> {
 }
 
 /// Old name for `Connection`. `SqliteConnection` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Connection instead")]
 pub type SqliteConnection = Connection;
 
 /// A connection to a SQLite database.
@@ -369,7 +369,7 @@ impl Connection {
     ///
     /// This method should be considered deprecated. Use `query_row` instead, which now
     /// does exactly the same thing.
-    #[deprecated]
+    #[deprecated(since = "0.1.0", note = "Use query_row instead")]
     pub fn query_row_safe<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
         where F: FnOnce(Row) -> T
     {
@@ -510,7 +510,7 @@ struct InnerConnection {
 }
 
 /// Old name for `OpenFlags`. `SqliteOpenFlags` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use OpenFlags instead")]
 pub type SqliteOpenFlags = OpenFlags;
 
 bitflags! {
@@ -682,7 +682,7 @@ impl Drop for InnerConnection {
 }
 
 /// Old name for `Statement`. `SqliteStatement` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Statement instead")]
 pub type SqliteStatement<'conn> = Statement<'conn>;
 
 /// A prepared statement.
@@ -972,7 +972,7 @@ impl<'stmt, T, E, F> Iterator for AndThenRows<'stmt, F>
 }
 
 /// Old name for `Rows`. `SqliteRows` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Rows instead")]
 pub type SqliteRows<'stmt> = Rows<'stmt>;
 
 /// An handle for the resulting rows of a query.
@@ -1037,7 +1037,7 @@ impl<'stmt> Drop for Rows<'stmt> {
 }
 
 /// Old name for `Row`. `SqliteRow` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Row instead")]
 pub type SqliteRow<'a, 'stmt> = Row<'a, 'stmt>;
 
 /// A single result row of a query.

--- a/src/load_extension_guard.rs
+++ b/src/load_extension_guard.rs
@@ -1,6 +1,7 @@
 use {Result, Connection};
 
 /// Old name for `LoadExtensionGuard`. `SqliteLoadExtensionGuard` is deprecated.
+#[deprecated]
 pub type SqliteLoadExtensionGuard<'conn> = LoadExtensionGuard<'conn>;
 
 /// RAII guard temporarily enabling SQLite extensions to be loaded.

--- a/src/load_extension_guard.rs
+++ b/src/load_extension_guard.rs
@@ -1,7 +1,7 @@
 use {Result, Connection};
 
 /// Old name for `LoadExtensionGuard`. `SqliteLoadExtensionGuard` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use LoadExtensionGuard instead")]
 pub type SqliteLoadExtensionGuard<'conn> = LoadExtensionGuard<'conn>;
 
 /// RAII guard temporarily enabling SQLite extensions to be loaded.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 use {Result, Connection};
 
 /// Old name for `TransactionBehavior`. `SqliteTransactionBehavior` is deprecated.
+#[deprecated]
 pub type SqliteTransactionBehavior = TransactionBehavior;
 
 /// Options for transaction behavior. See [BEGIN
@@ -28,6 +29,7 @@ pub enum DropBehavior {
 }
 
 /// Old name for `Transaction`. `SqliteTransaction` is deprecated.
+#[deprecated]
 pub type SqliteTransaction<'conn> = Transaction<'conn>;
 
 /// Represents a transaction on a database connection.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use {Result, Connection};
 
 /// Old name for `TransactionBehavior`. `SqliteTransactionBehavior` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use TransactionBehavior instead")]
 pub type SqliteTransactionBehavior = TransactionBehavior;
 
 /// Options for transaction behavior. See [BEGIN
@@ -29,7 +29,7 @@ pub enum DropBehavior {
 }
 
 /// Old name for `Transaction`. `SqliteTransaction` is deprecated.
-#[deprecated]
+#[deprecated(since = "0.6.0", note = "Use Transaction instead")]
 pub type SqliteTransaction<'conn> = Transaction<'conn>;
 
 /// Represents a transaction on a database connection.


### PR DESCRIPTION
Builds on #167 to include `since` and `note`.