### PR TITLE
Remove sanity check in `insert()` that could return `StatementFailedToInsertRow`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/jgallagher/rusqlite"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Version 0.7.3 (2016-06-01)
+
+* Fixes an incorrect failure from the `insert()` convenience function when back-to-back inserts to
+  different tables both returned the same row ID
+  ([#171](https://github.com/jgallagher/rusqlite/issues/171)).
+
 # Version 0.7.2 (2016-05-19)
 
 * BREAKING CHANGE: `Rows` no longer implements `Iterator`. It still has a `next()` method, but

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,10 +55,6 @@ pub enum Error {
     /// Error when a query that was expected to insert one row did not insert any or insert many.
     StatementChangedRows(c_int),
 
-    /// Error when a query that was expected to insert a row did not change the connection's
-    /// last_insert_rowid().
-    StatementFailedToInsertRow,
-
     /// Error returned by `functions::Context::get` when the function argument cannot be converted
     /// to the requested type.
     #[cfg(feature = "functions")]
@@ -105,7 +101,6 @@ impl fmt::Display for Error {
             Error::InvalidColumnName(ref name) => write!(f, "Invalid column name: {}", name),
             Error::InvalidColumnType => write!(f, "Invalid column type"),
             Error::StatementChangedRows(i) => write!(f, "Query changed {} rows", i),
-            Error::StatementFailedToInsertRow => write!(f, "Statement failed to insert new row"),
 
             #[cfg(feature = "functions")]
             Error::InvalidFunctionParameterType => write!(f, "Invalid function parameter type"),
@@ -136,7 +131,6 @@ impl error::Error for Error {
             Error::InvalidColumnName(_) => "invalid column name",
             Error::InvalidColumnType => "invalid column type",
             Error::StatementChangedRows(_) => "query inserted zero or more than one row",
-            Error::StatementFailedToInsertRow => "statement failed to insert new row",
 
             #[cfg(feature = "functions")]
             Error::InvalidFunctionParameterType => "invalid function parameter type",
@@ -161,8 +155,7 @@ impl error::Error for Error {
             Error::InvalidColumnName(_) |
             Error::InvalidColumnType |
             Error::InvalidPath(_) |
-            Error::StatementChangedRows(_) |
-            Error::StatementFailedToInsertRow => None,
+            Error::StatementChangedRows(_) => None,
 
             #[cfg(feature = "functions")]
             Error::InvalidFunctionParameterType => None,


### PR DESCRIPTION
This was intended to detect an `UPDATE` query passed to `insert`, but
incorrectly failed if inserts to different tables caused the same row ID
to be returned from both. `UPDATE`s are no longer detectable.

Closes #171.