### PR TITLE
change query_row* fns to take Row by reference instead of moving

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,12 +303,12 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
     pub fn query_row<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
-        where F: FnOnce(Row) -> T
+        where F: FnOnce(&Row) -> T
     {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query(params));
 
-        rows.get_expected_row().map(f)
+        rows.get_expected_row().map(|r| f(&r))
     }
 
     /// Convenience method to execute a query that is expected to return a single row,
@@ -339,13 +339,13 @@ impl Connection {
                                        params: &[&ToSql],
                                        f: F)
                                        -> result::Result<T, E>
-        where F: FnOnce(Row) -> result::Result<T, E>,
+        where F: FnOnce(&Row) -> result::Result<T, E>,
               E: convert::From<Error>
     {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query(params));
 
-        rows.get_expected_row().map_err(E::from).and_then(f)
+        rows.get_expected_row().map_err(E::from).and_then(|r| f(&r))
     }
 
     /// Convenience method to execute a query that is expected to return a single row.
@@ -369,7 +369,7 @@ impl Connection {
     /// does exactly the same thing.
     #[deprecated(since = "0.1.0", note = "Use query_row instead")]
     pub fn query_row_safe<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
-        where F: FnOnce(Row) -> T
+        where F: FnOnce(&Row) -> T
     {
         self.query_row(sql, params, f)
     }


### PR DESCRIPTION
This updates `query_row`, `query_row_and_then`, and `query_row_safe` (deprecated) to taking `Row` references instead of moving, bringing them in line with `query_and_then` and related fns.

This is a breaking change for uses of free functions, although should continue to work for most cases using closures:

```
stmt.query_row_and_then(&[], |r| r.get_checked(0)); // should continue to work
```

The difference between `query_row_and_then` and `query_and_then` is unergonomic esp. when using free functions as builder methods:

```
fn make_foo(r: Row) -> Foo { ... }
let foo = single_foo_stmt.query_row_and_then(&[], make_foo);
let foos = multi_foo_stmt.query_and_then(&[], make_foo); // make_foo has wrong signature

// requires duplicated impl:
fn make_foo_ref(r: &Row) -> Foo { ... }
let foos = multi_foo_stmt.query_and_then(&[], make_foo_ref);
```

Alternatively, these could be implemented as new fns and the old marked as deprecated, but IMO this is more API-consistent and the fix for breakage is straightforward.
