### PR TITLE
change query_row* fns to take Row by reference instead of moving

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@
   methods.
 * BREAKING CHANGE: The `ToSql` trait has been redesigned. It can now be implemented without
   `unsafe`, and implementors can choose to return either borrowed or owned results.
+* BREAKING CHANGE: The closure passed to `query_row`, `query_row_and_then`, `query_row_safe`,
+  and `query_row_named` now expects a `&Row` instead of a `Row`. The vast majority of calls
+  to these functions will probably not need to change; see
+  https://github.com/jgallagher/rusqlite/pull/184.
 * Added `#[deprecated(since = "...", note = "...")]` flags (new in Rust 1.9 for libraries) to
   all deprecated APIs.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,12 +303,12 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
     pub fn query_row<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
-        where F: FnOnce(Row) -> T
+        where F: FnOnce(&Row) -> T
     {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query(params));
 
-        rows.get_expected_row().map(f)
+        rows.get_expected_row().map(|r| f(&r))
     }
 
     /// Convenience method to execute a query that is expected to return a single row,
@@ -339,13 +339,13 @@ impl Connection {
                                        params: &[&ToSql],
                                        f: F)
                                        -> result::Result<T, E>
-        where F: FnOnce(Row) -> result::Result<T, E>,
+        where F: FnOnce(&Row) -> result::Result<T, E>,
               E: convert::From<Error>
     {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query(params));
 
-        rows.get_expected_row().map_err(E::from).and_then(f)
+        rows.get_expected_row().map_err(E::from).and_then(|r| f(&r))
     }
 
     /// Convenience method to execute a query that is expected to return a single row.
@@ -369,7 +369,7 @@ impl Connection {
     /// does exactly the same thing.
     #[deprecated(since = "0.1.0", note = "Use query_row instead")]
     pub fn query_row_safe<T, F>(&self, sql: &str, params: &[&ToSql], f: F) -> Result<T>
-        where F: FnOnce(Row) -> T
+        where F: FnOnce(&Row) -> T
     {
         self.query_row(sql, params, f)
     }

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -38,12 +38,12 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string or if the
     /// underlying SQLite call fails.
     pub fn query_row_named<T, F>(&self, sql: &str, params: &[(&str, &ToSql)], f: F) -> Result<T>
-        where F: FnOnce(Row) -> T
+        where F: FnOnce(&Row) -> T
     {
         let mut stmt = try!(self.prepare(sql));
         let mut rows = try!(stmt.query_named(params));
 
-        rows.get_expected_row().map(f)
+        rows.get_expected_row().map(|r| f(&r))
     }
 }
 


### PR DESCRIPTION
Builds on #184 (also changing `query_row_named` and updating Changelog).