### PR TITLE
Add Statement.query_row convenient method

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
   https://github.com/jgallagher/rusqlite/pull/184.
 * Added `#[deprecated(since = "...", note = "...")]` flags (new in Rust 1.9 for libraries) to
   all deprecated APIs.
+* Added `query_row` convenience function to `Statement`.
 * Fixed a bug where using cached prepared statements resulted in attempting to close a connection
   failing with `DatabaseBusy`; see https://github.com/jgallagher/rusqlite/issues/186.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,9 +306,7 @@ impl Connection {
         where F: FnOnce(&Row) -> T
     {
         let mut stmt = try!(self.prepare(sql));
-        let mut rows = try!(stmt.query(params));
-
-        rows.get_expected_row().map(|r| f(&r))
+        stmt.query_row(params, f)
     }
 
     /// Convenience method to execute a query that is expected to return a single row,


### PR DESCRIPTION
Builds on #180 with the following changes:

* Closure now takes a `&Row` to match changes made in #184 
* Updates Changelog