### PR TITLE
Better error reporting on invalid column type.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@
   and `query_row_named` now expects a `&Row` instead of a `Row`. The vast majority of calls
   to these functions will probably not need to change; see
   https://github.com/jgallagher/rusqlite/pull/184.
+* BREAKING CHANGE: A few cases of the `Error` enum have sprouted additional information
+  (e.g., `FromSqlConversionFailure` now also includes the column index and the type returned
+  by SQLite).
 * Added `#[deprecated(since = "...", note = "...")]` flags (new in Rust 1.9 for libraries) to
   all deprecated APIs.
 * Added `query_row` convenience function to `Statement`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     /// that column cannot be converted to the requested Rust type.
     InvalidColumnType(i32, Type),
 
+    /// Error when an SQLite value is requested, but the type of the result cannot be converted to the
+    /// requested Rust type.
+    InvalidType(Type),
+
     /// Error when a query that was expected to insert one row did not insert any or insert many.
     StatementChangedRows(c_int),
 
@@ -63,7 +67,7 @@ pub enum Error {
     /// Error returned by `functions::Context::get` when the function argument cannot be converted
     /// to the requested type.
     #[cfg(feature = "functions")]
-    InvalidFunctionParameterType(i32, Type),
+    InvalidFunctionParameterType(usize, Type),
 
     /// An error case available for implementors of custom user functions (e.g.,
     /// `create_scalar_function`).
@@ -107,6 +111,9 @@ impl fmt::Display for Error {
             Error::InvalidColumnType(i, ref t) => {
                 write!(f, "Invalid column type {} at index: {}", t, i)
             }
+            Error::InvalidType(ref t) => {
+                write!(f, "Invalid type {}", t)
+            }
             Error::StatementChangedRows(i) => write!(f, "Query changed {} rows", i),
             Error::StatementFailedToInsertRow => write!(f, "Statement failed to insert new row"),
 
@@ -140,6 +147,7 @@ impl error::Error for Error {
             Error::InvalidColumnIndex(_) => "invalid column index",
             Error::InvalidColumnName(_) => "invalid column name",
             Error::InvalidColumnType(_, _) => "invalid column type",
+            Error::InvalidType(_) => "invalid type",
             Error::StatementChangedRows(_) => "query inserted zero or more than one row",
             Error::StatementFailedToInsertRow => "statement failed to insert new row",
 
@@ -165,6 +173,7 @@ impl error::Error for Error {
             Error::InvalidColumnIndex(_) |
             Error::InvalidColumnName(_) |
             Error::InvalidColumnType(_, _) |
+            Error::InvalidType(_) |
             Error::InvalidPath(_) |
             Error::StatementChangedRows(_) |
             Error::StatementFailedToInsertRow => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
 
     /// Error when an SQLite value is requested, but the type of the result cannot be converted to the
     /// requested Rust type.
-    InvalidType(Type),
+    InvalidType,
 
     /// Error when a query that was expected to insert one row did not insert any or insert many.
     StatementChangedRows(c_int),
@@ -111,9 +111,7 @@ impl fmt::Display for Error {
             Error::InvalidColumnType(i, ref t) => {
                 write!(f, "Invalid column type {} at index: {}", t, i)
             }
-            Error::InvalidType(ref t) => {
-                write!(f, "Invalid type {}", t)
-            }
+            Error::InvalidType => write!(f, "Invalid type"),
             Error::StatementChangedRows(i) => write!(f, "Query changed {} rows", i),
             Error::StatementFailedToInsertRow => write!(f, "Statement failed to insert new row"),
 
@@ -147,7 +145,7 @@ impl error::Error for Error {
             Error::InvalidColumnIndex(_) => "invalid column index",
             Error::InvalidColumnName(_) => "invalid column name",
             Error::InvalidColumnType(_, _) => "invalid column type",
-            Error::InvalidType(_) => "invalid type",
+            Error::InvalidType => "invalid type",
             Error::StatementChangedRows(_) => "query inserted zero or more than one row",
             Error::StatementFailedToInsertRow => "statement failed to insert new row",
 
@@ -173,7 +171,7 @@ impl error::Error for Error {
             Error::InvalidColumnIndex(_) |
             Error::InvalidColumnName(_) |
             Error::InvalidColumnType(_, _) |
-            Error::InvalidType(_) |
+            Error::InvalidType |
             Error::InvalidPath(_) |
             Error::StatementChangedRows(_) |
             Error::StatementFailedToInsertRow => None,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -182,7 +182,7 @@ impl<'a> ValueRef<'a> {
 
                 ValueRef::Blob(from_raw_parts(blob as *const u8, len as usize))
             }
-            _ => unreachable!("sqlite3_value_type returned invalid value")
+            _ => unreachable!("sqlite3_value_type returned invalid value"),
         }
     }
 }
@@ -217,9 +217,9 @@ impl<'a> Context<'a> {
     pub fn get<T: FromSql>(&self, idx: usize) -> Result<T> {
         let arg = self.args[idx];
         let value = unsafe { ValueRef::from_value(arg) };
-        FromSql::column_result(value).map_err(|err| match err {
-            Error::InvalidColumnType => Error::InvalidFunctionParameterType,
-            _ => err
+        FromSql::column_result(value, idx as i32).map_err(|err| match err {
+            Error::InvalidColumnType(i, t) => Error::InvalidFunctionParameterType(i, t),
+            _ => err,
         })
     }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -217,8 +217,8 @@ impl<'a> Context<'a> {
     pub fn get<T: FromSql>(&self, idx: usize) -> Result<T> {
         let arg = self.args[idx];
         let value = unsafe { ValueRef::from_value(arg) };
-        FromSql::column_result(value, idx as i32).map_err(|err| match err {
-            Error::InvalidColumnType(i, t) => Error::InvalidFunctionParameterType(i, t),
+        FromSql::column_result(value).map_err(|err| match err {
+            Error::InvalidType(t) => Error::InvalidFunctionParameterType(idx, t),
             _ => err,
         })
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -218,7 +218,7 @@ impl<'a> Context<'a> {
         let arg = self.args[idx];
         let value = unsafe { ValueRef::from_value(arg) };
         FromSql::column_result(value).map_err(|err| match err {
-            Error::InvalidType(t) => Error::InvalidFunctionParameterType(idx, t),
+            Error::InvalidType => Error::InvalidFunctionParameterType(idx, value.data_type()),
             _ => err,
         })
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -62,7 +62,7 @@ pub use ffi::sqlite3_value;
 pub use ffi::sqlite3_value_type;
 pub use ffi::sqlite3_value_numeric_type;
 
-use types::{Null, FromSql, ValueRef};
+use types::{Null, FromSql, FromSqlError, ValueRef};
 
 use {Result, Error, Connection, str_to_cstring, InnerConnection};
 
@@ -218,8 +218,12 @@ impl<'a> Context<'a> {
         let arg = self.args[idx];
         let value = unsafe { ValueRef::from_value(arg) };
         FromSql::column_result(value).map_err(|err| match err {
-            Error::InvalidType => Error::InvalidFunctionParameterType(idx, value.data_type()),
-            _ => err,
+            FromSqlError::InvalidType => {
+                Error::InvalidFunctionParameterType(idx, value.data_type())
+            }
+            FromSqlError::Other(err) => {
+                Error::FromSqlConversionFailure(idx, value.data_type(), err)
+            }
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1066,7 +1066,10 @@ impl<'a, 'stmt> Row<'a, 'stmt> {
     pub fn get_checked<I: RowIndex, T: FromSql>(&self, idx: I) -> Result<T> {
         let idx = try!(idx.idx(self.stmt));
         let value = unsafe { ValueRef::new(&self.stmt.stmt, idx) };
-        FromSql::column_result(value, idx)
+        FromSql::column_result(value).map_err(|err| match err {
+            Error::InvalidType(t) => Error::InvalidColumnType(idx, t),
+            _ => err,
+        })
     }
 
     /// Return the number of columns in the current row.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,7 +1067,7 @@ impl<'a, 'stmt> Row<'a, 'stmt> {
         let idx = try!(idx.idx(self.stmt));
         let value = unsafe { ValueRef::new(&self.stmt.stmt, idx) };
         FromSql::column_result(value).map_err(|err| match err {
-            Error::InvalidType(t) => Error::InvalidColumnType(idx, t),
+            Error::InvalidType => Error::InvalidColumnType(idx, value.data_type()),
             _ => err,
         })
     }

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -21,8 +21,8 @@ impl ToSql for NaiveDate {
 
 /// "YYYY-MM-DD" => ISO 8601 calendar date without timezone.
 impl FromSql for NaiveDate {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_str(idx).and_then(|s| match NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_str().and_then(|s| match NaiveDate::parse_from_str(s, "%Y-%m-%d") {
             Ok(dt) => Ok(dt),
             Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
         })
@@ -39,8 +39,8 @@ impl ToSql for NaiveTime {
 
 /// "HH:MM"/"HH:MM:SS"/"HH:MM:SS.SSS" => ISO 8601 time without timezone.
 impl FromSql for NaiveTime {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_str(idx).and_then(|s| {
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_str().and_then(|s| {
             let fmt = match s.len() {
                 5 => "%H:%M",
                 8 => "%H:%M:%S",
@@ -65,8 +65,8 @@ impl ToSql for NaiveDateTime {
 /// "YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS" => ISO 8601 combined date and time
 /// without timezone. ("YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
 impl FromSql for NaiveDateTime {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_str(idx).and_then(|s| {
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_str().and_then(|s| {
             let fmt = if s.len() >= 11 && s.as_bytes()[10] == b'T' {
                 "%Y-%m-%dT%H:%M:%S%.f"
             } else {
@@ -91,10 +91,10 @@ impl<Tz: TimeZone> ToSql for DateTime<Tz> {
 
 /// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<UTC>.
 impl FromSql for DateTime<UTC> {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self> {
         {
             // Try to parse value as rfc3339 first.
-            let s = try!(value.as_str(idx));
+            let s = try!(value.as_str());
 
             // If timestamp looks space-separated, make a copy and replace it with 'T'.
             let s = if s.len() >= 11 && s.as_bytes()[10] == b' ' {
@@ -115,14 +115,14 @@ impl FromSql for DateTime<UTC> {
         }
 
         // Couldn't parse as rfc3339 - fall back to NaiveDateTime.
-        NaiveDateTime::column_result(value, idx).map(|dt| UTC.from_utc_datetime(&dt))
+        NaiveDateTime::column_result(value).map(|dt| UTC.from_utc_datetime(&dt))
     }
 }
 
 /// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<Local>.
 impl FromSql for DateTime<Local> {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        let utc_dt = try!(DateTime::<UTC>::column_result(value, idx));
+    fn column_result(value: ValueRef) -> Result<Self> {
+        let utc_dt = try!(DateTime::<UTC>::column_result(value));
         Ok(utc_dt.with_timezone(&Local))
     }
 }

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -6,8 +6,7 @@ use std::borrow::Cow;
 use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, UTC, Local};
 use libc::c_int;
 
-use {Error, Result};
-use types::{FromSql, ToSql, ValueRef};
+use types::{FromSql, FromSqlError, ToSql, ValueRef};
 
 use ffi::sqlite3_stmt;
 
@@ -21,10 +20,10 @@ impl ToSql for NaiveDate {
 
 /// "YYYY-MM-DD" => ISO 8601 calendar date without timezone.
 impl FromSql for NaiveDate {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_str().and_then(|s| match NaiveDate::parse_from_str(s, "%Y-%m-%d") {
             Ok(dt) => Ok(dt),
-            Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+            Err(err) => Err(FromSqlError::Other(Box::new(err))),
         })
     }
 }
@@ -39,7 +38,7 @@ impl ToSql for NaiveTime {
 
 /// "HH:MM"/"HH:MM:SS"/"HH:MM:SS.SSS" => ISO 8601 time without timezone.
 impl FromSql for NaiveTime {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_str().and_then(|s| {
             let fmt = match s.len() {
                 5 => "%H:%M",
@@ -48,7 +47,7 @@ impl FromSql for NaiveTime {
             };
             match NaiveTime::parse_from_str(s, fmt) {
                 Ok(dt) => Ok(dt),
-                Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                Err(err) => Err(FromSqlError::Other(Box::new(err))),
             }
         })
     }
@@ -65,7 +64,7 @@ impl ToSql for NaiveDateTime {
 /// "YYYY-MM-DD HH:MM:SS"/"YYYY-MM-DD HH:MM:SS.SSS" => ISO 8601 combined date and time
 /// without timezone. ("YYYY-MM-DDTHH:MM:SS"/"YYYY-MM-DDTHH:MM:SS.SSS" also supported)
 impl FromSql for NaiveDateTime {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_str().and_then(|s| {
             let fmt = if s.len() >= 11 && s.as_bytes()[10] == b'T' {
                 "%Y-%m-%dT%H:%M:%S%.f"
@@ -75,7 +74,7 @@ impl FromSql for NaiveDateTime {
 
             match NaiveDateTime::parse_from_str(s, fmt) {
                 Ok(dt) => Ok(dt),
-                Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+                Err(err) => Err(FromSqlError::Other(Box::new(err))),
             }
         })
     }
@@ -91,7 +90,7 @@ impl<Tz: TimeZone> ToSql for DateTime<Tz> {
 
 /// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<UTC>.
 impl FromSql for DateTime<UTC> {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         {
             // Try to parse value as rfc3339 first.
             let s = try!(value.as_str());
@@ -121,7 +120,7 @@ impl FromSql for DateTime<UTC> {
 
 /// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<Local>.
 impl FromSql for DateTime<Local> {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         let utc_dt = try!(DateTime::<UTC>::column_result(value));
         Ok(utc_dt.with_timezone(&Local))
     }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -4,34 +4,34 @@ use ::error::Error;
 
 /// A trait for types that can be created from a SQLite value.
 pub trait FromSql: Sized {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self>;
+    fn column_result(value: ValueRef) -> Result<Self>;
 }
 
 impl FromSql for i32 {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        i64::column_result(value, idx).map(|i| i as i32)
+    fn column_result(value: ValueRef) -> Result<Self> {
+        i64::column_result(value).map(|i| i as i32)
     }
 }
 
 impl FromSql for i64 {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_i64(idx)
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_i64()
     }
 }
 
 impl FromSql for f64 {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self> {
         match value {
             ValueRef::Integer(i) => Ok(i as f64),
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidColumnType(idx, value.data_type())),
+            _ => Err(Error::InvalidType(value.data_type())),
         }
     }
 }
 
 impl FromSql for bool {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        i64::column_result(value, idx).map(|i| match i {
+    fn column_result(value: ValueRef) -> Result<Self> {
+        i64::column_result(value).map(|i| match i {
             0 => false,
             _ => true,
         })
@@ -39,28 +39,28 @@ impl FromSql for bool {
 }
 
 impl FromSql for String {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_str(idx).map(|s| s.to_string())
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_str().map(|s| s.to_string())
     }
 }
 
 impl FromSql for Vec<u8> {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_blob(idx).map(|b| b.to_vec())
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_blob().map(|b| b.to_vec())
     }
 }
 
 impl<T: FromSql> FromSql for Option<T> {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self> {
         match value {
             ValueRef::Null => Ok(None),
-            _ => FromSql::column_result(value, idx).map(Some),
+            _ => FromSql::column_result(value).map(Some),
         }
     }
 }
 
 impl FromSql for Value {
-    fn column_result(value: ValueRef, _: i32) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self> {
         Ok(value.into())
     }
 }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -33,7 +33,7 @@ impl Error for FromSqlError {
     fn cause(&self) -> Option<&Error> {
         match *self {
             FromSqlError::InvalidType => None,
-            FromSqlError::Other(ref err) => Some(&**err),
+            FromSqlError::Other(ref err) => err.cause(),
         }
     }
 }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -1,36 +1,73 @@
 use super::{ValueRef, Value};
-use ::Result;
-use ::error::Error;
+use std::error::Error;
+use std::fmt;
+
+/// Enum listing possible errors from `FromSql` trait.
+#[derive(Debug)]
+pub enum FromSqlError {
+    /// Error when an SQLite value is requested, but the type of the result cannot be converted to the
+    /// requested Rust type.
+    InvalidType,
+    /// An error case available for implementors of the `FromSql` trait.
+    Other(Box<Error + Send + Sync>),
+}
+
+impl fmt::Display for FromSqlError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FromSqlError::InvalidType => write!(f, "Invalid type"),
+            FromSqlError::Other(ref err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for FromSqlError {
+    fn description(&self) -> &str {
+        match *self {
+            FromSqlError::InvalidType => "invalid type",
+            FromSqlError::Other(ref err) => err.description(),
+        }
+    }
+
+    #[cfg_attr(feature="clippy", allow(match_same_arms))]
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            FromSqlError::InvalidType => None,
+            FromSqlError::Other(ref err) => Some(&**err),
+        }
+    }
+}
+
 
 /// A trait for types that can be created from a SQLite value.
 pub trait FromSql: Sized {
-    fn column_result(value: ValueRef) -> Result<Self>;
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError>;
 }
 
 impl FromSql for i32 {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         i64::column_result(value).map(|i| i as i32)
     }
 }
 
 impl FromSql for i64 {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_i64()
     }
 }
 
 impl FromSql for f64 {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         match value {
             ValueRef::Integer(i) => Ok(i as f64),
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidType),
+            _ => Err(FromSqlError::InvalidType),
         }
     }
 }
 
 impl FromSql for bool {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         i64::column_result(value).map(|i| match i {
             0 => false,
             _ => true,
@@ -39,19 +76,19 @@ impl FromSql for bool {
 }
 
 impl FromSql for String {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_str().map(|s| s.to_string())
     }
 }
 
 impl FromSql for Vec<u8> {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_blob().map(|b| b.to_vec())
     }
 }
 
 impl<T: FromSql> FromSql for Option<T> {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         match value {
             ValueRef::Null => Ok(None),
             _ => FromSql::column_result(value).map(Some),
@@ -60,7 +97,7 @@ impl<T: FromSql> FromSql for Option<T> {
 }
 
 impl FromSql for Value {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         Ok(value.into())
     }
 }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -24,7 +24,7 @@ impl FromSql for f64 {
         match value {
             ValueRef::Integer(i) => Ok(i as f64),
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidType(value.data_type())),
+            _ => Err(Error::InvalidType),
         }
     }
 }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -4,34 +4,34 @@ use ::error::Error;
 
 /// A trait for types that can be created from a SQLite value.
 pub trait FromSql: Sized {
-    fn column_result(value: ValueRef) -> Result<Self>;
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self>;
 }
 
 impl FromSql for i32 {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        i64::column_result(value).map(|i| i as i32)
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        i64::column_result(value, idx).map(|i| i as i32)
     }
 }
 
 impl FromSql for i64 {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        value.as_i64()
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        value.as_i64(idx)
     }
 }
 
 impl FromSql for f64 {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
         match value {
             ValueRef::Integer(i) => Ok(i as f64),
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidColumnType),
+            _ => Err(Error::InvalidColumnType(idx, value.data_type())),
         }
     }
 }
 
 impl FromSql for bool {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        i64::column_result(value).map(|i| match i {
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        i64::column_result(value, idx).map(|i| match i {
             0 => false,
             _ => true,
         })
@@ -39,28 +39,28 @@ impl FromSql for bool {
 }
 
 impl FromSql for String {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        value.as_str().map(|s| s.to_string())
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        value.as_str(idx).map(|s| s.to_string())
     }
 }
 
 impl FromSql for Vec<u8> {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        value.as_blob().map(|b| b.to_vec())
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        value.as_blob(idx).map(|b| b.to_vec())
     }
 }
 
 impl<T: FromSql> FromSql for Option<T> {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
         match value {
             ValueRef::Null => Ok(None),
-            _ => FromSql::column_result(value).map(Some),
+            _ => FromSql::column_result(value, idx).map(Some),
         }
     }
 }
 
 impl FromSql for Value {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef, _: i32) -> Result<Self> {
         Ok(value.into())
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -56,6 +56,8 @@ pub use self::from_sql::FromSql;
 pub use self::to_sql::ToSql;
 pub use self::value_ref::ValueRef;
 
+use std::fmt;
+
 mod value_ref;
 mod from_sql;
 mod to_sql;
@@ -100,6 +102,39 @@ pub enum Value {
     Text(String),
     /// The value is a blob of data
     Blob(Vec<u8>),
+}
+
+impl Value {
+    pub fn data_type(&self) -> Type {
+        match *self {
+            Value::Null => Type::Null,
+            Value::Integer(_) => Type::Integer,
+            Value::Real(_) => Type::Real,
+            Value::Text(_) => Type::Text,
+            Value::Blob(_) => Type::Blob,
+        }
+    }
+}
+
+#[derive(Clone,Debug,PartialEq)]
+pub enum Type {
+    Null,
+    Integer,
+    Real,
+    Text,
+    Blob,
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Type::Null => write!(f, "Null"),
+            Type::Integer => write!(f, "Integer"),
+            Type::Real => write!(f, "Real"),
+            Type::Text => write!(f, "Text"),
+            Type::Blob => write!(f, "Blob"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -175,7 +210,7 @@ mod test {
     fn test_mismatched_types() {
         fn is_invalid_column_type(err: Error) -> bool {
             match err {
-                Error::InvalidColumnType => true,
+                Error::InvalidColumnType(_, _) => true,
                 _ => false,
             }
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -52,7 +52,7 @@
 
 pub use ffi::sqlite3_stmt;
 
-pub use self::from_sql::FromSql;
+pub use self::from_sql::{FromSql, FromSqlError};
 pub use self::to_sql::ToSql;
 pub use self::value_ref::ValueRef;
 

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -23,7 +23,7 @@ impl FromSql for Value {
         match value {
                 ValueRef::Text(ref s) => serde_json::from_str(s),
                 ValueRef::Blob(ref b) => serde_json::from_slice(b),
-                _ => return Err(Error::InvalidType(value.data_type())),
+                _ => return Err(Error::InvalidType),
             }
             .map_err(|err| Error::FromSqlConversionFailure(Box::new(err)))
     }

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -19,12 +19,13 @@ impl ToSql for Value {
 
 /// Deserialize text/blob to JSON `Value`.
 impl FromSql for Value {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
         match value {
-            ValueRef::Text(ref s) => serde_json::from_str(s),
-            ValueRef::Blob(ref b) => serde_json::from_slice(b),
-            _ => return Err(Error::InvalidColumnType),
-        }.map_err(|err| Error::FromSqlConversionFailure(Box::new(err)))
+                ValueRef::Text(ref s) => serde_json::from_str(s),
+                ValueRef::Blob(ref b) => serde_json::from_slice(b),
+                _ => return Err(Error::InvalidColumnType(idx, value.data_type())),
+            }
+            .map_err(|err| Error::FromSqlConversionFailure(Box::new(err)))
     }
 }
 

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -4,8 +4,7 @@ extern crate serde_json;
 use libc::c_int;
 use self::serde_json::Value;
 
-use {Error, Result};
-use types::{FromSql, ToSql, ValueRef};
+use types::{FromSql, FromSqlError, ToSql, ValueRef};
 
 use ffi::sqlite3_stmt;
 
@@ -19,13 +18,13 @@ impl ToSql for Value {
 
 /// Deserialize text/blob to JSON `Value`.
 impl FromSql for Value {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         match value {
                 ValueRef::Text(ref s) => serde_json::from_str(s),
                 ValueRef::Blob(ref b) => serde_json::from_slice(b),
-                _ => return Err(Error::InvalidType),
+                _ => return Err(FromSqlError::InvalidType),
             }
-            .map_err(|err| Error::FromSqlConversionFailure(Box::new(err)))
+            .map_err(|err| FromSqlError::Other(Box::new(err)))
     }
 }
 

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -19,11 +19,11 @@ impl ToSql for Value {
 
 /// Deserialize text/blob to JSON `Value`.
 impl FromSql for Value {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self> {
         match value {
                 ValueRef::Text(ref s) => serde_json::from_str(s),
                 ValueRef::Blob(ref b) => serde_json::from_slice(b),
-                _ => return Err(Error::InvalidColumnType(idx, value.data_type())),
+                _ => return Err(Error::InvalidType(value.data_type())),
             }
             .map_err(|err| Error::FromSqlConversionFailure(Box::new(err)))
     }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -16,8 +16,8 @@ impl ToSql for time::Timespec {
 }
 
 impl FromSql for time::Timespec {
-    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
-        value.as_str(idx).and_then(|s| match time::strptime(s, SQLITE_DATETIME_FMT) {
+    fn column_result(value: ValueRef) -> Result<Self> {
+        value.as_str().and_then(|s| match time::strptime(s, SQLITE_DATETIME_FMT) {
             Ok(tm) => Ok(tm.to_timespec()),
             Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
         })

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,8 +1,7 @@
 extern crate time;
 
 use libc::c_int;
-use {Error, Result};
-use types::{FromSql, ToSql, ValueRef};
+use types::{FromSql, FromSqlError, ToSql, ValueRef};
 
 use ffi::sqlite3_stmt;
 
@@ -16,10 +15,10 @@ impl ToSql for time::Timespec {
 }
 
 impl FromSql for time::Timespec {
-    fn column_result(value: ValueRef) -> Result<Self> {
+    fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         value.as_str().and_then(|s| match time::strptime(s, SQLITE_DATETIME_FMT) {
             Ok(tm) => Ok(tm.to_timespec()),
-            Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
+            Err(err) => Err(FromSqlError::Other(Box::new(err))),
         })
     }
 }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -16,8 +16,8 @@ impl ToSql for time::Timespec {
 }
 
 impl FromSql for time::Timespec {
-    fn column_result(value: ValueRef) -> Result<Self> {
-        value.as_str().and_then(|s| match time::strptime(s, SQLITE_DATETIME_FMT) {
+    fn column_result(value: ValueRef, idx: i32) -> Result<Self> {
+        value.as_str(idx).and_then(|s| match time::strptime(s, SQLITE_DATETIME_FMT) {
             Ok(tm) => Ok(tm.to_timespec()),
             Err(err) => Err(Error::FromSqlConversionFailure(Box::new(err))),
         })

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -1,6 +1,6 @@
 use ::Result;
 use ::error::Error;
-use super::Value;
+use super::{Value, Type};
 
 /// A non-owning [dynamic type value](http://sqlite.org/datatype3.html). Typically the
 /// memory backing this value is owned by SQLite.
@@ -21,39 +21,51 @@ pub enum ValueRef<'a> {
 }
 
 impl<'a> ValueRef<'a> {
+    pub fn data_type(&self) -> Type {
+        match *self {
+            ValueRef::Null => Type::Null,
+            ValueRef::Integer(_) => Type::Integer,
+            ValueRef::Real(_) => Type::Real,
+            ValueRef::Text(_) => Type::Text,
+            ValueRef::Blob(_) => Type::Blob,
+        }
+    }
+}
+
+impl<'a> ValueRef<'a> {
     /// If `self` is case `Integer`, returns the integral value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_i64(&self) -> Result<i64> {
+    pub fn as_i64(&self, idx: i32) -> Result<i64> {
         match *self {
             ValueRef::Integer(i) => Ok(i),
-            _ => Err(Error::InvalidColumnType),
+            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
         }
     }
 
     /// If `self` is case `Real`, returns the floating point value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_f64(&self) -> Result<f64> {
+    pub fn as_f64(&self, idx: i32) -> Result<f64> {
         match *self {
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidColumnType),
+            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
         }
     }
 
     /// If `self` is case `Text`, returns the string value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_str(&self) -> Result<&str> {
+    pub fn as_str(&self, idx: i32) -> Result<&str> {
         match *self {
             ValueRef::Text(ref t) => Ok(t),
-            _ => Err(Error::InvalidColumnType),
+            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
         }
     }
 
     /// If `self` is case `Blob`, returns the byte slice. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_blob(&self) -> Result<&[u8]> {
+    pub fn as_blob(&self, idx: i32) -> Result<&[u8]> {
         match *self {
             ValueRef::Blob(ref b) => Ok(b),
-            _ => Err(Error::InvalidColumnType),
+            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
         }
     }
 }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -1,5 +1,4 @@
-use ::Result;
-use ::error::Error;
+use ::types::FromSqlError;
 use super::{Value, Type};
 
 /// A non-owning [dynamic type value](http://sqlite.org/datatype3.html). Typically the
@@ -35,37 +34,37 @@ impl<'a> ValueRef<'a> {
 impl<'a> ValueRef<'a> {
     /// If `self` is case `Integer`, returns the integral value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_i64(&self) -> Result<i64> {
+    pub fn as_i64(&self) -> Result<i64, FromSqlError> {
         match *self {
             ValueRef::Integer(i) => Ok(i),
-            _ => Err(Error::InvalidType),
+            _ => Err(FromSqlError::InvalidType),
         }
     }
 
     /// If `self` is case `Real`, returns the floating point value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_f64(&self) -> Result<f64> {
+    pub fn as_f64(&self) -> Result<f64, FromSqlError> {
         match *self {
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidType),
+            _ => Err(FromSqlError::InvalidType),
         }
     }
 
     /// If `self` is case `Text`, returns the string value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_str(&self) -> Result<&str> {
+    pub fn as_str(&self) -> Result<&str, FromSqlError> {
         match *self {
             ValueRef::Text(ref t) => Ok(t),
-            _ => Err(Error::InvalidType),
+            _ => Err(FromSqlError::InvalidType),
         }
     }
 
     /// If `self` is case `Blob`, returns the byte slice. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_blob(&self) -> Result<&[u8]> {
+    pub fn as_blob(&self) -> Result<&[u8], FromSqlError> {
         match *self {
             ValueRef::Blob(ref b) => Ok(b),
-            _ => Err(Error::InvalidType),
+            _ => Err(FromSqlError::InvalidType),
         }
     }
 }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -38,7 +38,7 @@ impl<'a> ValueRef<'a> {
     pub fn as_i64(&self) -> Result<i64> {
         match *self {
             ValueRef::Integer(i) => Ok(i),
-            _ => Err(Error::InvalidType(self.data_type())),
+            _ => Err(Error::InvalidType),
         }
     }
 
@@ -47,7 +47,7 @@ impl<'a> ValueRef<'a> {
     pub fn as_f64(&self) -> Result<f64> {
         match *self {
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidType(self.data_type())),
+            _ => Err(Error::InvalidType),
         }
     }
 
@@ -56,7 +56,7 @@ impl<'a> ValueRef<'a> {
     pub fn as_str(&self) -> Result<&str> {
         match *self {
             ValueRef::Text(ref t) => Ok(t),
-            _ => Err(Error::InvalidType(self.data_type())),
+            _ => Err(Error::InvalidType),
         }
     }
 
@@ -65,7 +65,7 @@ impl<'a> ValueRef<'a> {
     pub fn as_blob(&self) -> Result<&[u8]> {
         match *self {
             ValueRef::Blob(ref b) => Ok(b),
-            _ => Err(Error::InvalidType(self.data_type())),
+            _ => Err(Error::InvalidType),
         }
     }
 }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -35,37 +35,37 @@ impl<'a> ValueRef<'a> {
 impl<'a> ValueRef<'a> {
     /// If `self` is case `Integer`, returns the integral value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_i64(&self, idx: i32) -> Result<i64> {
+    pub fn as_i64(&self) -> Result<i64> {
         match *self {
             ValueRef::Integer(i) => Ok(i),
-            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
+            _ => Err(Error::InvalidType(self.data_type())),
         }
     }
 
     /// If `self` is case `Real`, returns the floating point value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_f64(&self, idx: i32) -> Result<f64> {
+    pub fn as_f64(&self) -> Result<f64> {
         match *self {
             ValueRef::Real(f) => Ok(f),
-            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
+            _ => Err(Error::InvalidType(self.data_type())),
         }
     }
 
     /// If `self` is case `Text`, returns the string value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_str(&self, idx: i32) -> Result<&str> {
+    pub fn as_str(&self) -> Result<&str> {
         match *self {
             ValueRef::Text(ref t) => Ok(t),
-            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
+            _ => Err(Error::InvalidType(self.data_type())),
         }
     }
 
     /// If `self` is case `Blob`, returns the byte slice. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_blob(&self, idx: i32) -> Result<&[u8]> {
+    pub fn as_blob(&self) -> Result<&[u8]> {
         match *self {
             ValueRef::Blob(ref b) => Ok(b),
-            _ => Err(Error::InvalidColumnType(idx, self.data_type())),
+            _ => Err(Error::InvalidType(self.data_type())),
         }
     }
 }


### PR DESCRIPTION
Builds on #166. Mostly this is to handle merge conflicts. Additional changes:

* Adds a `FromSqlResult<T>` type to avoid having to use both `rusqlite::Result` and `std::result::Result` in the same file.
* Minor bugfix (2e140d0)
* Update Changelog
