### PR TITLE
Make Connection::close() return the connection on failure.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Version UPCOMING (TBD)
+
+* BREAKING CHANGE: `Connection::close()` now returns a `Result<(), (Connection, Error)>` instead
+  of a `Result<(), Error>` so callers get the still-open connection back on failure.
+
 # Version 0.8.0 (2016-12-31)
 
 * BREAKING CHANGE: The `FromSql` trait has been redesigned. It now requires a single, safe


### PR DESCRIPTION
Closes #199.