### PR TITLE
Fix close() returning a useful connection on failure.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,8 +608,11 @@ impl InnerConnection {
     fn close(&mut self) -> Result<()> {
         unsafe {
             let r = ffi::sqlite3_close(self.db());
-            self.db = ptr::null_mut();
-            self.decode_result(r)
+            let r = self.decode_result(r);
+            if r.is_ok() {
+                self.db = ptr::null_mut();
+            }
+            r
         }
     }
 
@@ -1277,13 +1280,14 @@ mod test {
             raw_stmt
         };
 
-        let result = db.close();
-        assert!(result.is_err());
+        // now that we have an open statement, trying (and retrying) to close should fail.
+        let (db, _) = db.close().unwrap_err();
+        let (db, _) = db.close().unwrap_err();
+        let (db, _) = db.close().unwrap_err();
 
-        // finalize the open statement so a second close will succeed
+        // finalize the open statement so a final close will succeed
         assert_eq!(ffi::SQLITE_OK, unsafe { ffi::sqlite3_finalize(raw_stmt) });
 
-        let (db, _) = result.unwrap_err();
         db.close().unwrap();
     }
 


### PR DESCRIPTION
As @gwenn pointed out on #200, `close()` was null-ing out the underlying connection even when close failed, so future close attempts would appear to succeed without actually closing the database.

This PR updates the test so that it failed due to the above bug, and fixes `close()`.