### PR TITLE
Fix doc comment example of FromSql/ToSql

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,19 +17,17 @@
 //! truncates timespecs to the nearest second. If you want different storage for timespecs, you can
 //! use a newtype. For example, to store timespecs as `f64`s:
 //!
-//! ```rust,ignore
+//! ```rust
 //! extern crate rusqlite;
-//! extern crate libc;
+//! extern crate time;
 //!
-//! use rusqlite::types::{FromSql, ToSql, sqlite3_stmt};
+//! use rusqlite::types::{FromSql, FromSqlResult, ValueRef, ToSql, ToSqlOutput};
 //! use rusqlite::{Result};
-//! use libc::c_int;
-//! use time;
 //!
 //! pub struct TimespecSql(pub time::Timespec);
 //!
 //! impl FromSql for TimespecSql {
-//!     fn column_result(value: ValueRef) -> Result<Self> {
+//!     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
 //!         f64::column_result(value).map(|as_f64| {
 //!             TimespecSql(time::Timespec{ sec: as_f64.trunc() as i64,
 //!                                         nsec: (as_f64.fract() * 1.0e9) as i32 })
@@ -38,12 +36,15 @@
 //! }
 //!
 //! impl ToSql for TimespecSql {
-//!     unsafe fn bind_parameter(&self, stmt: *mut sqlite3_stmt, col: c_int) -> c_int {
+//!     fn to_sql(&self) -> Result<ToSqlOutput> {
 //!         let TimespecSql(ts) = *self;
 //!         let as_f64 = ts.sec as f64 + (ts.nsec as f64) / 1.0e9;
-//!         as_f64.bind_parameter(stmt, col)
+//!         Ok(as_f64.into())
 //!     }
 //! }
+//!
+//! # // Prevent this doc test from being wrapped in a `fn main()` so that it will compile.
+//! # fn main() {}
 //! ```
 //!
 //! `ToSql` and `FromSql` are also implemented for `Option<T>` where `T` implements `ToSql` or


### PR DESCRIPTION
I modeled the changes to the example code after what I did when migrating my own code. Afterwords however, I noticed you used the more explicit (though more verbose) `ToSqlOutput::from` in types/to_sql.rs. Let me know if you'd like me to change the example to use that form.

While I'm at it, thanks for making this! Obviously I've found it useful 😀 