### PR TITLE
Upgrade dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/jgallagher/rusqlite"
@@ -26,17 +26,17 @@ trace = []
 bundled = ["libsqlite3-sys/bundled"]
 
 [dependencies]
-time = "~0.1.0"
+time = "0.1.0"
 bitflags = "0.7"
 lru-cache = "0.1.0"
-libc = "~0.2"
-chrono = { version = "~0.2", optional = true }
-serde_json = { version = "0.8", optional = true }
+libc = "0.2"
+chrono = { version = "0.2", optional = true }
+serde_json = { version = "0.9", optional = true }
 
 [dev-dependencies]
-tempdir = "~0.3.4"
-lazy_static = "~0.2"
-regex = "~0.2"
+tempdir = "0.3.4"
+lazy_static = "0.2"
+regex = "0.2"
 
 [dependencies.libsqlite3-sys]
 path = "libsqlite3-sys"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Version 0.9.4 (2017-01-25)
+
+* Update dependencies.
+
 # Version 0.9.3 (2017-01-23)
 
 * Make `ToSqlOutput` itself implement `ToSql`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  TARGET: 1.9.0-x86_64-pc-windows-gnu
+  TARGET: 1.14.0-x86_64-pc-windows-gnu
   MSYS2_BITS: 64
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsqlite3-sys"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 repository = "https://github.com/jgallagher/rusqlite"
 description = "Native bindings to the libsqlite3 library"
@@ -12,8 +12,8 @@ build = "build.rs"
 bundled = []
 
 [build-dependencies]
-pkg-config = "~0.3"
-gcc = "~0.3"
+pkg-config = "0.3"
+gcc = "0.3"
 
 [dependencies]
-libc = "~0.2"
+libc = "0.2"

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -13,7 +13,7 @@ fn main() {
         }
         Err(_) => {
             // See if pkg-config can do everything for us.
-            if !pkg_config::find_library("sqlite3").is_ok() {
+            if !pkg_config::Config::new().print_system_libs(false).probe("sqlite3").is_ok() {
                 // No env var set and pkg-config couldn't help; just output the link-lib
                 // request and hope that the library exists on the system paths. We used to
                 // output /usr/lib explicitly, but that can introduce other linking problems; see


### PR DESCRIPTION
In libsqlite3-sys, skip printing system libraries. See sfackler/rust-openssl#554.