### PR TITLE
Add more explicit types in unit tests.

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -258,7 +258,11 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(1i32,
-                       stmt.query_map(&[], |r| r.get(0)).unwrap().next().unwrap().unwrap());
+                       stmt.query_map::<i32, _>(&[], |r| r.get(0))
+                           .unwrap()
+                           .next()
+                           .unwrap()
+                           .unwrap());
         }
 
         db.execute_batch(r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1333,7 +1333,7 @@ mod test {
                    db.execute("INSERT INTO foo(x) VALUES (?)", &[&2i32]).unwrap());
 
         assert_eq!(3i32,
-                   db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
+                   db.query_row::<i32, _>("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
     }
 
     #[test]
@@ -1449,7 +1449,7 @@ mod test {
         db.execute_batch(sql).unwrap();
 
         assert_eq!(10i64,
-                   db.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0))
+                   db.query_row::<i64, _>("SELECT SUM(x) FROM foo", &[], |r| r.get(0))
                    .unwrap());
 
         let result: Result<i64> = db.query_row("SELECT x FROM foo WHERE x > 5", &[], |r| r.get(0));

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -229,9 +229,9 @@ mod test {
                    1);
 
         assert_eq!(3i32,
-                   db.query_row_named("SELECT SUM(x) FROM foo WHERE x > :x",
-                                        &[(":x", &0i32)],
-                                        |r| r.get(0))
+                   db.query_row_named::<i32, _>("SELECT SUM(x) FROM foo WHERE x > :x",
+                                                  &[(":x", &0i32)],
+                                                  |r| r.get(0))
                        .unwrap());
     }
 
@@ -246,9 +246,9 @@ mod test {
         stmt.execute_named(&[(":name", &"one")]).unwrap();
 
         assert_eq!(1i32,
-                   db.query_row_named("SELECT COUNT(*) FROM test WHERE name = :name",
-                                        &[(":name", &"one")],
-                                        |r| r.get(0))
+                   db.query_row_named::<i32, _>("SELECT COUNT(*) FROM test WHERE name = :name",
+                                                  &[(":name", &"one")],
+                                                  |r| r.get(0))
                        .unwrap());
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -427,7 +427,8 @@ mod test {
         {
             let tx = db.transaction().unwrap();
             assert_eq!(2i32,
-                       tx.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
+                       tx.query_row::<i32, _>("SELECT SUM(x) FROM foo", &[], |r| r.get(0))
+                           .unwrap());
         }
     }
 
@@ -453,7 +454,8 @@ mod test {
         {
             let tx = db.transaction().unwrap();
             assert_eq!(6i32,
-                       tx.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap());
+                       tx.query_row::<i32, _>("SELECT SUM(x) FROM foo", &[], |r| r.get(0))
+                           .unwrap());
         }
     }
 
@@ -547,7 +549,7 @@ mod test {
     }
 
     fn assert_current_sum(x: i32, conn: &Connection) {
-        let i = conn.query_row("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap();
+        let i = conn.query_row::<i32, _>("SELECT SUM(x) FROM foo", &[], |r| r.get(0)).unwrap();
         assert_eq!(x, i);
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -175,7 +175,7 @@ mod test {
         db.execute("INSERT INTO foo(i) VALUES (?)", &[&Value::Integer(10)]).unwrap();
 
         assert_eq!(10i64,
-                   db.query_row("SELECT i FROM foo", &[], |r| r.get(0)).unwrap());
+                   db.query_row::<i64, _>("SELECT i FROM foo", &[], |r| r.get(0)).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
I'm not sure why these changes are necessary. Some change in one of our dependencies (possibly `serde_json` judging from the CI logs on #221 and #222?) broke type inference for a handful of our unit tests.