### PR TITLE
Exporting libsqlite3_sys::error::ErrorCode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Version UPCOMING (TBD)
+
+* Re-export the `ErrorCode` enum from `libsqlite3-sys`.
+
 # Version 0.9.5 (2017-01-26)
 
 * Add impls of `Clone`, `Debug`, and `PartialEq` to `ToSqlOutput`.

--- a/libsqlite3-sys/src/error.rs
+++ b/libsqlite3-sys/src/error.rs
@@ -2,31 +2,56 @@ use libc::c_int;
 use std::error;
 use std::fmt;
 
+/// Error Codes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ErrorCode {
+    /// Internal logic error in SQLite
     InternalMalfunction,
+    /// Access permission denied
     PermissionDenied,
+    /// Callback routine requested an abort
     OperationAborted,
+    /// The database file is locked
     DatabaseBusy,
+    /// A table in the database is locked
     DatabaseLocked,
+    /// A malloc() failed
     OutOfMemory,
+    /// Attempt to write a readonly database
     ReadOnly,
+    /// Operation terminated by sqlite3_interrupt()
     OperationInterrupted,
+    /// Some kind of disk I/O error occurred
     SystemIOFailure,
+    /// The database disk image is malformed
     DatabaseCorrupt,
+    /// Unknown opcode in sqlite3_file_control()
     NotFound,
+    /// Insertion failed because database is full
     DiskFull,
+    /// Unable to open the database file
     CannotOpen,
+    /// Database lock protocol error
     FileLockingProtocolFailed,
+    /// The database schema changed
     SchemaChanged,
+    /// String or BLOB exceeds size limit
     TooBig,
+    /// Abort due to constraint violation
     ConstraintViolation,
+    /// Data type mismatch
     TypeMismatch,
+    /// Library used incorrectly
     APIMisuse,
+    /// Uses OS features not supported on host
     NoLargeFileSupport,
+    /// Authorization denied
     AuthorizationForStatementDenied,
+    /// 2nd parameter to sqlite3_bind out of range
     ParameterOutOfRange,
+    /// File opened that is not a database file
     NotADatabase,
+    /// SQL error or missing database
     Unknown,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub use transaction::{DropBehavior, Savepoint, Transaction, TransactionBehavior}
 #[allow(deprecated)]
 pub use error::SqliteError;
 pub use error::Error;
+pub use ffi::ErrorCode;
 
 pub use cache::CachedStatement;
 
@@ -1506,7 +1507,7 @@ mod test {
 
         match result.unwrap_err() {
             Error::SqliteFailure(err, _) => {
-                assert_eq!(err.code, ffi::ErrorCode::ConstraintViolation);
+                assert_eq!(err.code, ErrorCode::ConstraintViolation);
 
                 // extended error codes for constraints were added in SQLite 3.7.16; if we're
                 // running on a version at least that new, check for the extended code


### PR DESCRIPTION
Builds on #222, picking up changes from master that should allow CI to pass and adding a note to the changelog.