### PR TITLE
Expose version(), version_number(), and source_id() functions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Version UPCOMING (TBD)
 
 * Re-export the `ErrorCode` enum from `libsqlite3-sys`.
+* Adds `version()`, `version_number()`, and `source_id()` functions for querying the version of
+  SQLite in use.
 
 # Version 0.9.5 (2017-01-26)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,14 @@ pub use error::Error;
 pub use ffi::ErrorCode;
 
 pub use cache::CachedStatement;
+pub use version::*;
 
 #[cfg(feature = "load_extension")]
 #[allow(deprecated)]
 pub use load_extension_guard::{SqliteLoadExtensionGuard, LoadExtensionGuard};
 
 pub mod types;
+mod version;
 mod transaction;
 mod cache;
 mod named_params;
@@ -1511,13 +1513,22 @@ mod test {
 
                 // extended error codes for constraints were added in SQLite 3.7.16; if we're
                 // running on a version at least that new, check for the extended code
-                let version = unsafe { ffi::sqlite3_libversion_number() };
-                if version >= 3007016 {
+                if version_number() >= 3007016 {
                     assert_eq!(err.extended_code, ffi::SQLITE_CONSTRAINT_NOTNULL)
                 }
             }
             err => panic!("Unexpected error {}", err),
         }
+    }
+
+    #[test]
+    fn test_version_string() {
+        let n = version_number();
+        let major = n / 1_000_000;
+        let minor = (n % 1_000_000) / 1_000;
+        let patch = n % 1_000;
+
+        assert_eq!(version(), format!("{}.{}.{}", major, minor, patch));
     }
 
     mod query_and_then_tests {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,25 @@
+use ffi;
+use std::ffi::CStr;
+
+/// Returns the SQLite version as an integer; e.g., `3016002` for version 3.16.2.
+///
+/// See [sqlite3_libversion_number()](https://www.sqlite.org/c3ref/libversion.html).
+pub fn version_number() -> i32 {
+    unsafe { ffi::sqlite3_libversion_number() }
+}
+
+/// Returns the SQLite version as a string; e.g., `"3.16.2"` for version 3.16.2.
+///
+/// See [sqlite3_libversion()](https://www.sqlite.org/c3ref/libversion.html).
+pub fn version() -> &'static str {
+    let cstr = unsafe { CStr::from_ptr(ffi::sqlite3_libversion()) };
+    cstr.to_str().expect("SQLite version string is not valid UTF8 ?!")
+}
+
+/// Returns the source ID of SQLite, identifying the commit of SQLite for the current version.
+///
+/// See [sqlite3_sourceid()](https://www.sqlite.org/c3ref/libversion.html).
+pub fn source_id() -> &'static str {
+    let cstr = unsafe { CStr::from_ptr(ffi::sqlite3_sourceid()) };
+    cstr.to_str().expect("SQLite source ID is not valid UTF8 ?!")
+}


### PR DESCRIPTION
Closes #224.