### PR TITLE
Clarify support of older SQLite versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.9.5"
+version = "0.10.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/jgallagher/rusqlite"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,13 @@
-# Version UPCOMING (TBD)
+# Version 0.10.0-UPCOMING (TBD)
 
 * Re-export the `ErrorCode` enum from `libsqlite3-sys`.
-* Adds `version()`, `version_number()`, and `source_id()` functions for querying the version of
-  SQLite in use.
+* Adds `version()` and `version_number()` functions for querying the version of SQLite in use.
+* Adds the `limits` feature, exposing `limit()` and `set_limit()` methods on `Connection`.
+* Updates to `libsqlite3-sys` 0.7.0, which runs rust-bindgen at build-time instead of assuming the
+  precense of all expected SQLite constants and functions.
+* Clarifies supported SQLite versions. Running with SQLite older than 3.6.8 now panics, and
+  some features will not compile unless a sufficiently-recent SQLite version is used. See
+  the README for requirements of particular features.
 
 # Version 0.9.5 (2017-01-26)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ fn main() {
 }
 ```
 
+### Supported SQLite Versions
+
+The base `rusqlite` package supports SQLite version 3.6.8 or newer. If you need
+support for older versions, please file an issue. Some cargo features require a
+newer SQLite version; see details below.
+
 ### Optional Features
 
 Rusqlite provides several features that are behind [Cargo
@@ -65,12 +71,13 @@ features](http://doc.crates.io/manifest.html#the-features-section). They are:
 * [`load_extension`](http://jgallagher.github.io/rusqlite/rusqlite/struct.LoadExtensionGuard.html)
   allows loading dynamic library-based SQLite extensions.
 * [`backup`](http://jgallagher.github.io/rusqlite/rusqlite/backup/index.html)
-  allows use of SQLite's online backup API.
+  allows use of SQLite's online backup API. Note: This feature requires SQLite 3.6.11 or later.
 * [`functions`](http://jgallagher.github.io/rusqlite/rusqlite/functions/index.html)
   allows you to load Rust closures into SQLite connections for use in queries.
   Note: This feature requires SQLite 3.7.3 or later.
 * [`trace`](http://jgallagher.github.io/rusqlite/rusqlite/trace/index.html)
-  allows hooks into SQLite's tracing and profiling APIs.
+  allows hooks into SQLite's tracing and profiling APIs. Note: This feature
+  requires SQLite 3.6.23 or later.
 * [`blob`](http://jgallagher.github.io/rusqlite/rusqlite/blob/index.html)
   gives `std::io::{Read, Write, Seek}` access to SQL BLOBs. Note: This feature
   requires SQLite 3.7.4 or later.

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -56,8 +56,11 @@ mod test {
         db.set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 99);
         assert_eq!(99, db.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER));
 
-        db.set_limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH, 32);
-        assert_eq!(32, db.limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH));
+        // SQLITE_LIMIT_TRIGGER_DEPTH was added in SQLite 3.6.18.
+        if ::version_number() >= 3006018 {
+            db.set_limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH, 32);
+            assert_eq!(32, db.limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH));
+        }
 
         // SQLITE_LIMIT_WORKER_THREADS was added in SQLite 3.8.7.
         if ::version_number() >= 3008007 {

--- a/src/version.rs
+++ b/src/version.rs
@@ -15,11 +15,3 @@ pub fn version() -> &'static str {
     let cstr = unsafe { CStr::from_ptr(ffi::sqlite3_libversion()) };
     cstr.to_str().expect("SQLite version string is not valid UTF8 ?!")
 }
-
-/// Returns the source ID of SQLite, identifying the commit of SQLite for the current version.
-///
-/// See [sqlite3_sourceid()](https://www.sqlite.org/c3ref/libversion.html).
-pub fn source_id() -> &'static str {
-    let cstr = unsafe { CStr::from_ptr(ffi::sqlite3_sourceid()) };
-    cstr.to_str().expect("SQLite source ID is not valid UTF8 ?!")
-}

--- a/tests/deny_single_threaded_sqlite_config.rs
+++ b/tests/deny_single_threaded_sqlite_config.rs
@@ -7,14 +7,17 @@ extern crate libsqlite3_sys as ffi;
 use rusqlite::Connection;
 
 #[test]
+#[should_panic]
 fn test_error_when_singlethread_mode() {
     // put SQLite into single-threaded mode
     unsafe {
-        // 1 == SQLITE_CONFIG_SINGLETHREAD
-        assert_eq!(ffi::sqlite3_config(1), ffi::SQLITE_OK);
-        println!("{}", ffi::sqlite3_mutex_alloc(0) as u64);
+        if ffi::sqlite3_config(ffi::SQLITE_CONFIG_SINGLETHREAD) != ffi::SQLITE_OK {
+            return;
+        }
+        if ffi::sqlite3_initialize() != ffi::SQLITE_OK {
+            return;
+        }
     }
 
-    let result = Connection::open_in_memory();
-    assert!(result.is_err());
+    let _ = Connection::open_in_memory().unwrap();
 }


### PR DESCRIPTION
I ran our test suite against several old SQLite versions and made the following changes based on the results:

* Added a note to the README and a panic at runtime that we require SQLite 3.6.8 or newer. 3.6.8 is 8 years old at this point. It's the version that added support for `SAVEPOINT`. Most of rusqlite still functions correctly on older versions, but I'd rather add a hard cutoff and adjust that backwards if anyone runs into problems.
* The test we have for nonsensical open flags (e.g., `READONLY | READ_WRITE`) relied on a check SQLite performs, but that wasn't added until 3.7.3. I replicated that check so we still perform it even when linked against older SQLite versions.
* The check we perform to ensure SQLite isn't configured for single-threaded use causes SQLite versions older than 3.7.0 to segfault. When running against 3.6.x, we now attempt to call `sqlite3_config` and `sqlite3_initialize` ourselves when the first connection is opened; if that fails, we panic, since we can't guarantee our API is actually safe. There is a new unsafe function `bypass_sqlite_initialization` that skips this check. Behavior when running with 3.7.0 or newer is unchanged, and `bypass_sqlite_initialization` does nothing.
* Removes the `source_id()` function. This was added in 3.6.18, and doesn't seem important enough to warrant a feature. We've never shipped a rusqlite version with this present anyway.