### PR TITLE
Fix URL Markdown syntax in Connection docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ impl Connection {
 
     /// Open a new connection to a SQLite database.
     ///
-    /// Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
     /// flag combinations.
     ///
     /// # Failure
@@ -228,7 +228,7 @@ impl Connection {
 
     /// Open a new connection to an in-memory SQLite database.
     ///
-    /// Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
     /// flag combinations.
     ///
     /// # Failure


### PR DESCRIPTION
Fix malformed Markdown URL syntax in both ``Connection::open_with_flags`` and ``Connection::open_in_memory_with_flags`` docs.