### PR TITLE
Remove the dependency on `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ limits = []
 time = "0.1.0"
 bitflags = "0.7"
 lru-cache = "0.1.0"
-libc = "0.2"
 chrono = { version = "0.3", optional = true }
 serde_json = { version = "0.9", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 * Clarifies supported SQLite versions. Running with SQLite older than 3.6.8 now panics, and
   some features will not compile unless a sufficiently-recent SQLite version is used. See
   the README for requirements of particular features.
+* Removes the `libc` dependency in favor of using `std::os::raw`
 
 # Version 0.9.5 (2017-01-26)
 

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -15,6 +15,3 @@ bundled = []
 bindgen = "0.21"
 pkg-config = "0.3"
 gcc = "0.3"
-
-[dependencies]
-libc = "0.2"

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -27,7 +27,6 @@ fn run_bindgen<T: Into<String>>(header: T) {
     let mut output = Vec::new();
     bindgen::builder()
         .header(header.clone())
-        .ctypes_prefix("::libc")
         .type_chooser(Box::new(SqliteTypeChooser))
         .generate()
         .expect(&format!("could not run bindgen on header {}", header))

--- a/libsqlite3-sys/src/error.rs
+++ b/libsqlite3-sys/src/error.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use std::os::raw::c_int;
 use std::error;
 use std::fmt;
 

--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(non_snake_case, non_camel_case_types)]
 
-extern crate libc;
-
 pub use self::error::*;
 
 use std::mem;

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -30,7 +30,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::ptr;
 
-use libc::c_int;
+use std::os::raw::c_int;
 use std::thread;
 use std::time::Duration;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::error;
 use std::fmt;
 use std::path::PathBuf;
 use std::str;
-use libc::c_int;
+use std::os::raw::c_int;
 use {ffi, errmsg_to_string};
 use types::Type;
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -54,7 +54,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::slice;
-use libc::{c_int, c_char, c_void};
+use std::os::raw::{c_int, c_char, c_void};
 
 use ffi;
 use ffi::sqlite3_context;
@@ -508,7 +508,7 @@ mod test {
     extern crate regex;
 
     use std::collections::HashMap;
-    use libc::c_double;
+    use std::os::raw::c_double;
     use self::regex::Regex;
     use std::f64::EPSILON;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
 //! ```
 #![allow(unknown_lints)]
 
-extern crate libc;
 extern crate libsqlite3_sys as ffi;
 extern crate lru_cache;
 #[macro_use]
@@ -74,7 +73,7 @@ use std::result;
 use std::str;
 use std::sync::{Once, ONCE_INIT};
 use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
-use libc::{c_int, c_char, c_void};
+use std::os::raw::{c_int, c_char, c_void};
 
 use types::{ToSql, ToSqlOutput, FromSql, FromSqlError, ValueRef};
 use error::{error_from_sqlite_code, error_from_handle};
@@ -534,7 +533,7 @@ bitflags! {
     #[doc = "Flags for opening SQLite database connections."]
     #[doc = "See [sqlite3_open_v2](http://www.sqlite.org/c3ref/open.html) for details."]
     #[repr(C)]
-    pub flags OpenFlags: ::libc::c_int {
+    pub flags OpenFlags: ::std::os::raw::c_int {
         const SQLITE_OPEN_READ_ONLY     = 0x00000001,
         const SQLITE_OPEN_READ_WRITE    = 0x00000002,
         const SQLITE_OPEN_CREATE        = 0x00000004,
@@ -742,7 +741,7 @@ impl InnerConnection {
                 Ok(())
             } else {
                 let message = errmsg_to_string(&*errmsg);
-                ffi::sqlite3_free(errmsg as *mut libc::c_void);
+                ffi::sqlite3_free(errmsg as *mut ::std::os::raw::c_void);
                 Err(error_from_sqlite_code(r, Some(message)))
             }
         }
@@ -1357,7 +1356,7 @@ mod test {
         let raw_stmt = {
             use std::mem;
             use std::ptr;
-            use libc::c_int;
+            use std::os::raw::c_int;
             use super::str_to_cstring;
 
             let raw_db = db.db.borrow_mut().db;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,6 +1,6 @@
 //! Run-Time Limits
 
-use libc::c_int;
+use std::os::raw::c_int;
 
 use ffi;
 pub use ffi::Limit;

--- a/src/named_params.rs
+++ b/src/named_params.rs
@@ -1,6 +1,6 @@
 use std::convert;
 use std::result;
-use libc::c_int;
+use std::os::raw::c_int;
 
 use {Result, Error, Connection, Statement, MappedRows, AndThenRows, Rows, Row, str_to_cstring};
 use types::ToSql;

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 use std::ptr;
-use libc::c_int;
+use std::os::raw::c_int;
 use super::ffi;
 
 // Private newtype for raw sqlite3_stmts that finalize themselves when dropped.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,6 +1,6 @@
 //! Tracing and profiling functions. Error and warning log.
 
-use libc::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::ptr;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -73,11 +73,10 @@ mod serde_json;
 /// ## Example
 ///
 /// ```rust,no_run
-/// # extern crate libc;
 /// # extern crate rusqlite;
 /// # use rusqlite::{Connection, Result};
 /// # use rusqlite::types::{Null};
-/// # use libc::{c_int};
+/// # use std::os::raw::{c_int};
 /// fn main() {
 /// }
 /// fn insert_null(conn: &Connection) -> Result<c_int> {
@@ -114,7 +113,7 @@ mod test {
 
     use Connection;
     use Error;
-    use libc::{c_int, c_double};
+    use std::os::raw::{c_int, c_double};
     use std::f64::EPSILON;
     use super::Value;
 

--- a/tests/config_log.rs
+++ b/tests/config_log.rs
@@ -3,12 +3,11 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate libc;
 extern crate rusqlite;
 
 #[cfg(feature = "trace")]
 fn main() {
-    use libc::c_int;
+    use std::os::raw::c_int;
     use std::sync::Mutex;
 
     lazy_static! {


### PR DESCRIPTION
Recent versions of bindgen use `std::os::raw` over `libc`, but currently
`libsqlite3-sys` is overriding that. `std::os::raw` is a subset of
`libc` that exports only the relevant type definitions, but not any
functions which require additional linking. This enables
`libsqlite3-sys` to be more easily used on targets that may not have a
libc available (presumably sqlite itself would have been compiled with
musl in that case)