### PR TITLE
Set HAVE_USLEEP

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -34,6 +34,7 @@ mod build {
             .flag("-DSQLITE_SOUNDEX")
             .flag("-DSQLITE_THREADSAFE=1")
             .flag("-DSQLITE_USE_URI")
+            .flag("-DHAVE_USLEEP=1")
             .compile("libsqlite3.a");
     }
 }


### PR DESCRIPTION
SQLite otherwise has to sleep for a second at a time when waiting for a
lock (!)

usleep is truly ancient so I don't think there will be platforms that don't actually have it.

There are some other flags like this: https://sqlite.org/compile.html. Might be worth doing some configure-style detection of them?