### PR TITLE
Add example for enabling bundled features in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ adjust this behavior in a couple of ways:
   [gcc](https://crates.io/crates/gcc) crate to compile SQLite from source and
   link against that. This source is embedded in the `libsqlite3-sys` crate and
   is currently SQLite 3.17.0 (as of `rusqlite` 0.10.1 / `libsqlite3-sys`
-  0.7.1).  This is probably the simplest solution to any build problems.
+  0.7.1).  This is probably the simplest solution to any build problems. You can enable this by adding the following in your `Cargo.toml` file:
+  ```
+  [dependencies.rusqlite]
+  version = "0.11.0"
+  features = ["bundled"]
+  ```
 * You can set the `SQLITE3_LIB_DIR` to point to directory containing the SQLite
   library.
 


### PR DESCRIPTION
I'm quite new to Rust, especially with using `*-sys` crates. Yesterday I spent way more time than necessary trying to link and compile rusqlite on Windows. I knew that the "bundled" features was the way to go, but I was not able to find how to enable it (as I said, noob here!)

I think that adding this 3 lines snippet in the `README` can help new rustaceans! Especially because the `bundled` feature is the only real reliable way to use rusqlite on Windows. :) 