### PR TITLE
for msvc abi builds, add support for using sqlite from a vcpkg installation if available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 environment:
-  TARGET: 1.15.0-x86_64-pc-windows-gnu
-  MSYS2_BITS: 64
+  matrix:
+  - TARGET: 1.15.0-x86_64-pc-windows-gnu
+    MSYS2_BITS: 64
+  - TARGET: 1.15.0-x86_64-pc-windows-msvc
+    VCPKG_DEFAULT_TRIPLET: x64-windows
+  - TARGET: nightly-x86_64-pc-windows-msvc
+    VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    RUSTFLAGS: -Ctarget-feature=+crt-static
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe"
   - rust-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
@@ -9,11 +15,18 @@ install:
   - rustc -V
   - cargo -V
   - ps: Start-FileDownload 'https://sqlite.org/2017/sqlite-dll-win64-x64-3170000.zip' # download SQLite dll (useful only when the `bundled` feature is not set)
-  - cmd: 7z e sqlite-dll-win64-x64-3170000.zip -y > nul
+  - if not defined VCPKG_DEFAULT_TRIPLET 7z e sqlite-dll-win64-x64-3170000.zip -y > nul
   - ps: Start-FileDownload 'https://sqlite.org/2017/sqlite-amalgamation-3170000.zip' # download SQLite headers (useful only when the `bundled` feature is not set)
-  - cmd: 7z e sqlite-amalgamation-3170000.zip -y > nul
-  - SET SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER% # specify where the SQLite dll has been downloaded (useful only when the `bundled` feature is not set)
-  - SET SQLITE3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER% # specify where the SQLite headers have been downloaded (useful only when the `bundled` feature is not set)
+  - if not defined VCPKG_DEFAULT_TRIPLET 7z e sqlite-amalgamation-3170000.zip -y > nul
+  - if not defined VCPKG_DEFAULT_TRIPLET SET SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER% # specify where the SQLite dll has been downloaded (useful only when the `bundled` feature is not set)
+  - if not defined VCPKG_DEFAULT_TRIPLET SET SQLITE3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER% # specify where the SQLite headers have been downloaded (useful only when the `bundled` feature is not set)
+  # install vcpkg and the sqlite3 package
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install sqlite3
+  - if defined VCPKG_DEFAULT_TRIPLET appveyor DownloadFile http://releases.llvm.org/4.0.0/LLVM-4.0.0-win64.exe
+  - if defined VCPKG_DEFAULT_TRIPLET LLVM-4.0.0-win64.exe /S
 
 build: false
 

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -25,4 +25,6 @@ min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
 bindgen = { version = "0.21", optional = true }
 pkg-config = { version = "0.3", optional = true }
 gcc = { version = "0.3", optional = true }
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = { version = "0.2", optional = true }

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -13,15 +13,16 @@ categories = ["database", "external-ffi-bindings"]
 [features]
 default = ["min_sqlite_version_3_6_8"]
 bundled = ["gcc"]
-buildtime_bindgen = ["bindgen", "pkg-config"]
-min_sqlite_version_3_6_8 = ["pkg-config"]
-min_sqlite_version_3_6_11 = ["pkg-config"]
-min_sqlite_version_3_6_23 = ["pkg-config"]
-min_sqlite_version_3_7_3 = ["pkg-config"]
-min_sqlite_version_3_7_4 = ["pkg-config"]
-min_sqlite_version_3_7_16 = ["pkg-config"]
+buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
+min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
+min_sqlite_version_3_6_11 = ["pkg-config", "vcpkg"]
+min_sqlite_version_3_6_23 = ["pkg-config", "vcpkg"]
+min_sqlite_version_3_7_3 = ["pkg-config", "vcpkg"]
+min_sqlite_version_3_7_4 = ["pkg-config", "vcpkg"]
+min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
 
 [build-dependencies]
 bindgen = { version = "0.21", optional = true }
 pkg-config = { version = "0.3", optional = true }
 gcc = { version = "0.3", optional = true }
+vcpkg = { version = "0.2", optional = true }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -42,7 +42,7 @@ mod build {
 mod build {
     extern crate pkg_config;
 
-    #[cfg(feature = "vcpkg")]
+    #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     extern crate vcpkg;
 
     use std::env;
@@ -107,7 +107,7 @@ mod build {
         }
     }
 
-    #[cfg(feature = "vcpkg")]
+    #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     fn try_vcpkg() -> Option<HeaderLocation> {
         // See if vcpkg can find it.
         if let Ok(mut lib) = vcpkg::Config::new().probe("sqlite3") {
@@ -119,7 +119,7 @@ mod build {
         None
     }
 
-    #[cfg(not(feature = "vcpkg"))]
+    #[cfg(not(all(feature = "vcpkg", target_env = "msvc")))]
     fn try_vcpkg() -> Option<HeaderLocation> {
         None
     }


### PR DESCRIPTION
This is with a view to enabling more easy `cargo install` of Diesel on windows.  [Vcpkg](https://github.com/Microsoft/vcpkg) is a newish Microsoft maintained collection of packages, like a ports tree or brew.

There is a script [here](https://github.com/mcgoo/vcpkg_diesel_build) that demonstrates building a totally static diesel.exe with Postgres, MySQL and Sqlite. It's more or less:

```
vcpkg --triplet x64-windows-static install libpq sqlite3 libmysql
set RUSTFLAGS=-Ctarget-feature=+crt-static
cargo install diesel_cli
```
The corresponding PRs for the -sys crates for [PostgreSQL](https://github.com/sgrif/pq-sys/pull/13) and [MySQL](https://github.com/sgrif/mysqlclient-sys/pull/4).

Thanks very much for taking the time to consider this PR.