### PR TITLE
msvc/vcpkg dynamic builds now require explicit opt-in

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     MSYS2_BITS: 64
   - TARGET: 1.15.0-x86_64-pc-windows-msvc
     VCPKG_DEFAULT_TRIPLET: x64-windows
+    VCPKGRS_DYNAMIC: 1
   - TARGET: nightly-x86_64-pc-windows-msvc
     VCPKG_DEFAULT_TRIPLET: x64-windows-static
     RUSTFLAGS: -Ctarget-feature=+crt-static


### PR DESCRIPTION
The build helper was changed to require explicit opt-in for linking dynamically, otherwise `cargo install` using the msvc toolchain would prefer dynamically linking if Vcpkg is installed resulting in binaries that won't work without a PATH adjustment. This commit makes the appveyor build opt-in.