### PR TITLE
Fixed loss of time information during string conversion

### DIFF
--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -3,7 +3,7 @@ extern crate time;
 use Result;
 use types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
-const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
+const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%f %z";
 
 impl ToSql for time::Timespec {
     fn to_sql(&self) -> Result<ToSqlOutput> {

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -3,7 +3,7 @@ extern crate time;
 use Result;
 use types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
-const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%f";
+const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S:%f";
 
 impl ToSql for time::Timespec {
     fn to_sql(&self) -> Result<ToSqlOutput> {

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -3,7 +3,7 @@ extern crate time;
 use Result;
 use types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
-const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%f %z";
+const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%f";
 
 impl ToSql for time::Timespec {
     fn to_sql(&self) -> Result<ToSqlOutput> {

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -42,15 +42,27 @@ mod test {
     fn test_timespec() {
         let db = checked_memory_handle();
 
-        let ts = time::Timespec {
-            sec: 10_000,
-            nsec: 0,
-        };
-        db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts])
-            .unwrap();
+        let mut ts_vec = vec![];
 
-        let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0))
-            .unwrap();
-        assert_eq!(from, ts);
+        ts_vec.push(time::Timespec::new(10_000, 0));//January 1, 1970 2:46:40 AM
+        ts_vec.push(time::Timespec::new(10_000, 1000));//January 1, 1970 2:46:40 AM (and one microsecond)
+        ts_vec.push(time::Timespec::new(1500391124, 1_000_000));//July 18, 2017
+        ts_vec.push(time::Timespec::new(2000000000, 2_000_000));//May 18, 2033
+        ts_vec.push(time::Timespec::new(3000000000, 999_999_999));//January 24, 2065
+        ts_vec.push(time::Timespec::new(10000000000, 0));//November 20, 2286
+
+        for ts in ts_vec {
+
+            db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts])
+                .unwrap();
+
+            let from: time::Timespec = db.query_row("SELECT t FROM foo", &[], |r| r.get(0))
+                .unwrap();
+
+            db.execute("DELETE FROM foo", &[]).unwrap();
+
+            assert_eq!(from, ts);
+        }
+
     }
 }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -3,7 +3,7 @@ extern crate time;
 use Result;
 use types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
-const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S:%f";
+const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S:%f %Z";
 
 impl ToSql for time::Timespec {
     fn to_sql(&self) -> Result<ToSqlOutput> {


### PR DESCRIPTION
Uploading a Timespec looses the nanosecond data.

I checked for leap-second, leap-year and daylight saving times, but it appears to all be correct.

%d should take leap years in account, %f the leap seconds, and at_utc should take care of any timezone/daylight-savings problems.