### PR TITLE
Export RowIndex trait to allow external code to be generic over what can index be

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use cache::StatementCache;
 pub use statement::Statement;
 use statement::StatementCrateImpl;
 
-pub use row::{Row, Rows, MappedRows, AndThenRows};
+pub use row::{Row, Rows, MappedRows, AndThenRows, RowIndex};
 use row::RowsCrateImpl;
 
 #[allow(deprecated)]


### PR DESCRIPTION
It's useful for using in external libraries which tie closely with rusqlite