### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ limits = []
 
 [dependencies]
 time = "0.1.0"
-bitflags = "0.9"
+bitflags = "1.0"
 lru-cache = "0.1"
-chrono = { version = "0.3", optional = true }
+chrono = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["database", "external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]
-bundled = ["gcc"]
+bundled = ["cc"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
 min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_6_11 = ["pkg-config", "vcpkg"]
@@ -22,9 +22,9 @@ min_sqlite_version_3_7_4 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
 
 [build-dependencies]
-bindgen = { version = "0.23", optional = true }
+bindgen = { version = "0.30", optional = true }
 pkg-config = { version = "0.3", optional = true }
-gcc = { version = "0.3", optional = true }
+cc = { version = "1.0", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = { version = "0.2", optional = true }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -4,7 +4,7 @@ fn main() {
 
 #[cfg(feature = "bundled")]
 mod build {
-    extern crate gcc;
+    extern crate cc;
     use std::{env, fs};
     use std::path::Path;
 
@@ -14,7 +14,7 @@ mod build {
         fs::copy("sqlite3/bindgen_bundled_version.rs", out_path)
             .expect("Could not copy bindings to output directory");
 
-        gcc::Config::new()
+        cc::Build::new()
             .file("sqlite3/sqlite3.c")
             .flag("-DSQLITE_CORE")
             .flag("-DSQLITE_DEFAULT_FOREIGN_KEYS=1")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,7 +599,8 @@ bitflags! {
 
 impl Default for OpenFlags {
     fn default() -> OpenFlags {
-        SQLITE_OPEN_READ_WRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NO_MUTEX | SQLITE_OPEN_URI
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE | 
+        OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_URI
     }
 }
 
@@ -737,9 +738,9 @@ impl InnerConnection {
 
         // Replicate the check for sane open flags from SQLite, because the check in SQLite itself
         // wasn't added until version 3.7.3.
-        debug_assert!(1 << SQLITE_OPEN_READ_ONLY.bits == 0x02);
-        debug_assert!(1 << SQLITE_OPEN_READ_WRITE.bits == 0x04);
-        debug_assert!(1 << (SQLITE_OPEN_READ_WRITE | SQLITE_OPEN_CREATE).bits == 0x40);
+        debug_assert!(1 << OpenFlags::SQLITE_OPEN_READ_ONLY.bits == 0x02);
+        debug_assert!(1 << OpenFlags::SQLITE_OPEN_READ_WRITE.bits == 0x04);
+        debug_assert!(1 << (OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE).bits == 0x40);
         if (1 << (flags.bits & 0x7)) & 0x46 == 0 {
             return Err(Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_MISUSE), None));
         }
@@ -976,8 +977,8 @@ mod test {
     #[test]
     fn test_open_with_flags() {
         for bad_flags in &[OpenFlags::empty(),
-                           SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_READ_WRITE,
-                           SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_CREATE] {
+                           OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_READ_WRITE,
+                           OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_CREATE] {
             assert!(Connection::open_in_memory_with_flags(*bad_flags).is_err());
         }
     }

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -3,7 +3,7 @@ extern crate chrono;
 
 use std::borrow::Cow;
 
-use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, UTC, Local};
+use self::chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, TimeZone, Utc, Local};
 
 use Result;
 use types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
@@ -87,12 +87,12 @@ impl FromSql for NaiveDateTime {
 /// Date and time with time zone => UTC RFC3339 timestamp ("YYYY-MM-DDTHH:MM:SS.SSS+00:00").
 impl<Tz: TimeZone> ToSql for DateTime<Tz> {
     fn to_sql(&self) -> Result<ToSqlOutput> {
-        Ok(ToSqlOutput::from(self.with_timezone(&UTC).to_rfc3339()))
+        Ok(ToSqlOutput::from(self.with_timezone(&Utc).to_rfc3339()))
     }
 }
 
-/// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<UTC>.
-impl FromSql for DateTime<UTC> {
+/// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<Utc>.
+impl FromSql for DateTime<Utc> {
     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
         {
             // Try to parse value as rfc3339 first.
@@ -111,19 +111,19 @@ impl FromSql for DateTime<UTC> {
             };
 
             if let Ok(dt) = DateTime::parse_from_rfc3339(&s) {
-                return Ok(dt.with_timezone(&UTC));
+                return Ok(dt.with_timezone(&Utc));
             }
         }
 
         // Couldn't parse as rfc3339 - fall back to NaiveDateTime.
-        NaiveDateTime::column_result(value).map(|dt| UTC.from_utc_datetime(&dt))
+        NaiveDateTime::column_result(value).map(|dt| Utc.from_utc_datetime(&dt))
     }
 }
 
 /// RFC3339 ("YYYY-MM-DDTHH:MM:SS.SSS[+-]HH:MM") into DateTime<Local>.
 impl FromSql for DateTime<Local> {
     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
-        let utc_dt = try!(DateTime::<UTC>::column_result(value));
+        let utc_dt = try!(DateTime::<Utc>::column_result(value));
         Ok(utc_dt.with_timezone(&Local))
     }
 }
@@ -131,7 +131,7 @@ impl FromSql for DateTime<Local> {
 #[cfg(test)]
 mod test {
     use Connection;
-    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, UTC,
+    use super::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
                         Duration};
 
     fn checked_memory_handle() -> Connection {
@@ -201,7 +201,7 @@ mod test {
         let date = NaiveDate::from_ymd(2016, 2, 23);
         let time = NaiveTime::from_hms_milli(23, 56, 4, 789);
         let dt = NaiveDateTime::new(date, time);
-        let utc = UTC.from_utc_datetime(&dt);
+        let utc = Utc.from_utc_datetime(&dt);
 
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&utc])
             .unwrap();
@@ -210,19 +210,19 @@ mod test {
             .unwrap();
         assert_eq!("2016-02-23T23:56:04.789+00:00", s);
 
-        let v1: DateTime<UTC> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0))
+        let v1: DateTime<Utc> = db.query_row("SELECT t FROM foo", &[], |r| r.get(0))
             .unwrap();
         assert_eq!(utc, v1);
 
-        let v2: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04.789'", &[], |r| r.get(0))
+        let v2: DateTime<Utc> = db.query_row("SELECT '2016-02-23 23:56:04.789'", &[], |r| r.get(0))
             .unwrap();
         assert_eq!(utc, v2);
 
-        let v3: DateTime<UTC> = db.query_row("SELECT '2016-02-23 23:56:04'", &[], |r| r.get(0))
+        let v3: DateTime<Utc> = db.query_row("SELECT '2016-02-23 23:56:04'", &[], |r| r.get(0))
             .unwrap();
         assert_eq!(utc - Duration::milliseconds(789), v3);
 
-        let v4: DateTime<UTC> =
+        let v4: DateTime<Utc> =
             db.query_row("SELECT '2016-02-23 23:56:04.789+00:00'", &[], |r| r.get(0))
                 .unwrap();
         assert_eq!(utc, v4);


### PR DESCRIPTION
* Gcc crate has been renamed to cc.
* Chrono::UTC has been renamed to Chrono::Utc.
* bitflags 1.0 uses associated constants. So prefix OpenFlags.