### PR TITLE
Add support for linking to SQLCipher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: rust
 
@@ -13,12 +14,10 @@ matrix:
 
 addons:
   apt:
-    sources:
-      - llvm-toolchain-precise-3.9
-      - ubuntu-toolchain-r-test
     packages: # recommanded versions for rust-bindgen
       - llvm-3.9-dev
       - libclang-3.9-dev
+      - libsqlcipher-dev
 
 env: # specify the clang path for rust-bindgen
   - LIBCLANG_PATH=/usr/lib/llvm-3.9/lib
@@ -26,6 +25,7 @@ env: # specify the clang path for rust-bindgen
 script:
   - cargo build
   - cargo build --features bundled
+  - cargo build --features sqlcipher
   - cargo test
   - cargo test --features backup
   - cargo test --features blob
@@ -36,6 +36,7 @@ script:
   - cargo test --features chrono
   - cargo test --features serde_json
   - cargo test --features bundled
+  - cargo test --features sqlcipher
   - cargo test --features "backup blob chrono functions limits load_extension serde_json trace"
   - cargo test --features "backup blob chrono functions limits load_extension serde_json trace buildtime_bindgen"
   - cargo test --features "backup blob chrono functions limits load_extension serde_json trace bundled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ trace = ["libsqlite3-sys/min_sqlite_version_3_6_23"]
 bundled = ["libsqlite3-sys/bundled"]
 buildtime_bindgen = ["libsqlite3-sys/buildtime_bindgen"]
 limits = []
+sqlcipher = ["libsqlite3-sys/sqlcipher"]
 
 [dependencies]
 time = "0.1.0"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -7,13 +7,14 @@ description = "Native bindings to the libsqlite3 library"
 license = "MIT"
 links = "sqlite3"
 build = "build.rs"
-keywords = ["sqlite", "database", "ffi"]
+keywords = ["sqlite", "sqlcipher", "database", "ffi"]
 categories = ["database", "external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]
 bundled = ["gcc"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
+sqlcipher = []
 min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_6_11 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_6_23 = ["pkg-config", "vcpkg"]

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -9,6 +9,10 @@ mod build {
     use std::path::Path;
 
     pub fn main() {
+        if cfg!(feature = "sqlcipher") {
+            panic!("Builds with bundled SQLCipher are not supported");
+        }
+
         let out_dir = env::var("OUT_DIR").unwrap();
         let out_path = Path::new(&out_dir).join("bindgen.rs");
         fs::copy("sqlite3/bindgen_bundled_version.rs", out_path)
@@ -58,8 +62,9 @@ mod build {
         fn from(header: HeaderLocation) -> String {
             match header {
                 HeaderLocation::FromEnvironment => {
-                    let mut header = env::var("SQLITE3_INCLUDE_DIR")
-                        .expect("SQLITE3_INCLUDE_DIR must be set if SQLITE3_LIB_DIR is set");
+                    let prefix = env_prefix();
+                    let mut header = env::var(format!("{}_INCLUDE_DIR", prefix))
+                        .expect(&format!("{}_INCLUDE_DIR must be set if {}_LIB_DIR is set", prefix, prefix));
                     header.push_str("/sqlite3.h");
                     header
                 }
@@ -76,9 +81,11 @@ mod build {
 
     // Prints the necessary cargo link commands and returns the path to the header.
     fn find_sqlite() -> HeaderLocation {
+        let link_lib = link_lib();
+
         // Allow users to specify where to find SQLite.
-        if let Ok(dir) = env::var("SQLITE3_LIB_DIR") {
-            println!("cargo:rustc-link-lib=sqlite3");
+        if let Ok(dir) = env::var(format!("{}_LIB_DIR", env_prefix())) {
+            println!("cargo:rustc-link-lib={}", link_lib);
             println!("cargo:rustc-link-search={}", dir);
             return HeaderLocation::FromEnvironment;
         }
@@ -88,7 +95,7 @@ mod build {
         }
 
         // See if pkg-config can do everything for us.
-        match pkg_config::Config::new().print_system_libs(false).probe("sqlite3") {
+        match pkg_config::Config::new().print_system_libs(false).probe(link_lib) {
             Ok(mut lib) => {
                 if let Some(mut header) = lib.include_paths.pop() {
                     header.push("sqlite3.h");
@@ -102,7 +109,7 @@ mod build {
                 // request and hope that the library exists on the system paths. We used to
                 // output /usr/lib explicitly, but that can introduce other linking problems; see
                 // https://github.com/jgallagher/rusqlite/issues/207.
-                println!("cargo:rustc-link-lib=sqlite3");
+                println!("cargo:rustc-link-lib={}", link_lib);
                 HeaderLocation::Wrapper
             }
         }
@@ -111,7 +118,7 @@ mod build {
     #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     fn try_vcpkg() -> Option<HeaderLocation> {
         // See if vcpkg can find it.
-        if let Ok(mut lib) = vcpkg::Config::new().probe("sqlite3") {
+        if let Ok(mut lib) = vcpkg::Config::new().probe(link_lib()) {
             if let Some(mut header) = lib.include_paths.pop() {
                 header.push("sqlite3.h");
                 return Some(HeaderLocation::FromPath(header.to_string_lossy().into()));
@@ -123,6 +130,22 @@ mod build {
     #[cfg(not(all(feature = "vcpkg", target_env = "msvc")))]
     fn try_vcpkg() -> Option<HeaderLocation> {
         None
+    }
+
+    fn env_prefix() -> &'static str {
+        if cfg!(feature = "sqlcipher") {
+            "SQLCIPHER"
+        } else {
+            "SQLITE3"
+        }
+    }
+
+    fn link_lib() -> &'static str {
+        if cfg!(feature = "sqlcipher") {
+            "sqlcipher"
+        } else {
+            "sqlite3"
+        }
     }
 
     #[cfg(not(feature = "buildtime_bindgen"))]


### PR DESCRIPTION
This PR should partially address #219 by making it possible to link against the SQLCipher library. This PR does not expose the two additional functions from SQLCipher's API (since they can be used via PRAGMA statements anyway) and it will eventually be the scope of a future PR. This PR only adds support for SQLCipher in non-bundled mode (requesting bundled mode should result in a build failure).