### PR TITLE
Update `bindgen` dependency to the latest version

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -22,7 +22,7 @@ min_sqlite_version_3_7_4 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
 
 [build-dependencies]
-bindgen = { version = "0.23", optional = true }
+bindgen = { version = "0.31.3", optional = true }
 pkg-config = { version = "0.3", optional = true }
 gcc = { version = "0.3", optional = true }
 

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -202,7 +202,7 @@ mod build {
             // was added in SQLite 3.8.3, but oring it in in prior versions of SQLite is harmless. We
             // don't want to not build just because this flag is missing (e.g., if we're linking against
             // SQLite 3.7.x), so append the flag manually if it isn't present in bindgen's output.
-            if !output.contains("pub const SQLITE_DETERMINISTIC:") {
+            if !output.contains("pub const SQLITE_DETERMINISTIC") {
                 output.push_str("\npub const SQLITE_DETERMINISTIC: i32 = 2048;\n");
             }
 


### PR DESCRIPTION
This also required adjusting the fixup inserting `SQLITE_DETERMINISTIC` into the bindings if it was missing. Now that `bindgen` uses the `quote` crate for code generation, instead of `syntex`, we can't rely on the output being formatted (it only is formatted if there is a usable `rustfmt` on the `$PATH`). Even better than this `contains` tweak would be switching to regexps or something.

Despite that formatting hiccup, newer `bindgen` releases are more reliable due to many bug fixes, and also build in approximately half the time that older `bindgen` versions do.