### PR TITLE
 Update `bindgen` dependency to the latest version

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -22,7 +22,7 @@ min_sqlite_version_3_7_4 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
 
 [build-dependencies]
-bindgen = { version = "0.30", optional = true }
+bindgen = { version = "0.31", optional = true }
 pkg-config = { version = "0.3", optional = true }
 cc = { version = "1.0", optional = true }
 

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -202,7 +202,7 @@ mod build {
             // was added in SQLite 3.8.3, but oring it in in prior versions of SQLite is harmless. We
             // don't want to not build just because this flag is missing (e.g., if we're linking against
             // SQLite 3.7.x), so append the flag manually if it isn't present in bindgen's output.
-            if !output.contains("pub const SQLITE_DETERMINISTIC:") {
+            if !output.contains("pub const SQLITE_DETERMINISTIC") {
                 output.push_str("\npub const SQLITE_DETERMINISTIC: i32 = 2048;\n");
             }
 


### PR DESCRIPTION
This is #301 merged with latest master. Should fix CI builds.

I had errors with this change locally until I updated to rustfmt-nightly; see rust-lang-nursery/rust-bindgen#1150.