### PR TITLE
Update doc links to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.12.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/jgallagher/rusqlite"
-documentation = "http://jgallagher.github.io/rusqlite/rusqlite/index.html"
+documentation = "http://docs.rs/rusqlite/"
 readme = "README.md"
 keywords = ["sqlite", "database", "ffi"]
 license = "MIT"
@@ -50,3 +50,9 @@ harness = false
 
 [[test]]
 name = "deny_single_threaded_sqlite_config"
+
+[package.metadata.docs.rs]
+features = [ "backup", "blob", "chrono", "functions", "load_extension", "serde_json", "trace" ]
+all-features = false
+no-default-features = true
+default-target = "x86_64-unknown-linux-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ harness = false
 name = "deny_single_threaded_sqlite_config"
 
 [package.metadata.docs.rs]
-features = [ "backup", "blob", "chrono", "functions", "load_extension", "serde_json", "trace" ]
+features = [ "backup", "blob", "chrono", "functions", "limits", "load_extension", "serde_json", "trace" ]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Rusqlite is an ergonomic wrapper for using SQLite from Rust. It attempts to expose
 an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres). View the full
-[API documentation](http://jgallagher.github.io/rusqlite/rusqlite/index.html).
+[API documentation](http://docs.rs/rusqlite/).
 
 ```rust
 extern crate rusqlite;


### PR DESCRIPTION
This is #182 merged with latest master. Adds `limits` feature to docs.rs instructions.