### PR TITLE
Remove the database keyword/category from libsqlite3-sys

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -7,8 +7,8 @@ description = "Native bindings to the libsqlite3 library"
 license = "MIT"
 links = "sqlite3"
 build = "build.rs"
-keywords = ["sqlite", "sqlcipher", "database", "ffi"]
-categories = ["database", "external-ffi-bindings"]
+keywords = ["sqlite", "sqlcipher", "ffi"]
+categories = ["external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]


### PR DESCRIPTION
Currently `libsqlite3-sys` is the first result for both the "database"
keyword, and the "Database interfaces" category. This makes sense, as it
is a dependency of both Diesel and rusqlite. However, this library is
not intended to be used directly. While it can technically be called a
database interface, FFI is clearly the category that applies more than
anything else. Someone browsing this keyword or category is likely
looking for a Rust library they can use, not a C one.