### PR TITLE
Add comment to justify `&mut Connection` in `Transaction`

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -94,6 +94,9 @@ pub struct Savepoint<'conn> {
 
 impl<'conn> Transaction<'conn> {
     /// Begin a new transaction. Cannot be nested; see `savepoint` for nested transactions.
+    // Even though we don't mutate the connection, we take a `&mut Connection`
+    // so as to prevent nested or concurrent transactions on the same
+    // connection.
     pub fn new(conn: &mut Connection, behavior: TransactionBehavior) -> Result<Transaction> {
         let query = match behavior {
             TransactionBehavior::Deferred => "BEGIN DEFERRED",


### PR DESCRIPTION
The `Transaction` implementation never actually mutates the `Connection` reference we give it.  In fact, the `Transaction` structure itself only requires an immutable connection.  So it can be surprising to readers that the constructor requires a `&mut Connection`.  We do this so as to prevent at compile-time nested or concurrent transactions on the same connection as these are not allowed by SQLite.

In this commit, we add a comment explaining this nuance.