### PR TITLE
Add flag to allow opening DB with write-ahead logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,7 @@ bitflags! {
         const SQLITE_OPEN_FULL_MUTEX    = ffi::SQLITE_OPEN_FULLMUTEX;
         const SQLITE_OPEN_SHARED_CACHE  = 0x0002_0000;
         const SQLITE_OPEN_PRIVATE_CACHE = 0x0004_0000;
+        const SQLITE_OPEN_WAL           = 0x0008_0000;
     }
 }
 


### PR DESCRIPTION
Background: https://www.sqlite.org/wal.html

The OPEN_WAL flag is in the 3.7.3+ bindgen bindings, the sqlite3.h header, and in the bundled_version bindings, so this seemed safe.  The constant is specified as 524288 there; I obviously went for consistency here.

The unit tests still pass, and I was able to use the flag in a local project with an open_with_flags call specifying OpenFlags::SQLITE_OPEN_WAL.

cc: @jgallagher and @gwenn for adding the other constants in this section.