### PR TITLE
Check that only one statement is provided (#397)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -95,6 +95,9 @@ pub enum Error {
     #[cfg(feature = "vtab")]
     #[allow(dead_code)]
     ModuleError(String),
+
+    /// Error when the SQL contains multiple statements.
+    MultipleStatement,
 }
 
 impl From<str::Utf8Error> for Error {
@@ -155,6 +158,7 @@ impl fmt::Display for Error {
             Error::InvalidQuery => write!(f, "Query is not read-only"),
             #[cfg(feature = "vtab")]
             Error::ModuleError(ref desc) => write!(f, "{}", desc),
+            Error::MultipleStatement => write!(f, "Multiple statements provided"),
         }
     }
 }
@@ -192,6 +196,7 @@ impl error::Error for Error {
             Error::InvalidQuery => "query is not read-only",
             #[cfg(feature = "vtab")]
             Error::ModuleError(ref desc) => desc,
+            Error::MultipleStatement => "multiple statements provided",
         }
     }
 
@@ -211,7 +216,8 @@ impl error::Error for Error {
             | Error::InvalidColumnType(_, _)
             | Error::InvalidPath(_)
             | Error::StatementChangedRows(_)
-            | Error::InvalidQuery => None,
+            | Error::InvalidQuery
+            | Error::MultipleStatement => None,
 
             #[cfg(feature = "functions")]
             Error::InvalidFunctionParameterType(_, _) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,8 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string
     /// or if the underlying SQLite call fails.
     pub fn execute(&self, sql: &str, params: &[&ToSql]) -> Result<usize> {
-        self.prepare(sql).and_then(|mut stmt| stmt.execute(params))
+        self.prepare(sql)
+            .and_then(|mut stmt| stmt.check_no_tail().and_then(|_| stmt.execute(params)))
     }
 
     /// Convenience method to prepare and execute a single SQL statement with
@@ -344,8 +345,10 @@ impl Connection {
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string
     /// or if the underlying SQLite call fails.
     pub fn execute_named(&self, sql: &str, params: &[(&str, &ToSql)]) -> Result<usize> {
-        self.prepare(sql)
-            .and_then(|mut stmt| stmt.execute_named(params))
+        self.prepare(sql).and_then(|mut stmt| {
+            stmt.check_no_tail()
+                .and_then(|_| stmt.execute_named(params))
+        })
     }
 
     /// Get the SQLite rowid of the most recent successful INSERT.
@@ -384,6 +387,7 @@ impl Connection {
         F: FnOnce(&Row) -> T,
     {
         let mut stmt = try!(self.prepare(sql));
+        try!(stmt.check_no_tail());
         stmt.query_row(params, f)
     }
 
@@ -402,6 +406,7 @@ impl Connection {
         F: FnOnce(&Row) -> T,
     {
         let mut stmt = try!(self.prepare(sql));
+        try!(stmt.check_no_tail());
         let mut rows = try!(stmt.query_named(params));
 
         rows.get_expected_row().map(|r| f(&r))
@@ -443,6 +448,7 @@ impl Connection {
         E: convert::From<Error>,
     {
         let mut stmt = try!(self.prepare(sql));
+        try!(stmt.check_no_tail());
         let mut rows = try!(stmt.query(params));
 
         rows.get_expected_row().map_err(E::from).and_then(|r| f(&r))
@@ -954,6 +960,7 @@ impl InnerConnection {
         let mut c_stmt: *mut ffi::sqlite3_stmt = unsafe { mem::uninitialized() };
         let c_sql = try!(str_to_cstring(sql));
         let len_with_nul = (sql.len() + 1) as c_int;
+        let mut c_tail = ptr::null();
         let r = unsafe {
             if cfg!(feature = "unlock_notify") {
                 let mut rc;
@@ -963,7 +970,7 @@ impl InnerConnection {
                         c_sql.as_ptr(),
                         len_with_nul,
                         &mut c_stmt,
-                        ptr::null_mut(),
+                        &mut c_tail,
                     );
                     if !unlock_notify::is_locked(self.db, rc) {
                         break;
@@ -980,12 +987,16 @@ impl InnerConnection {
                     c_sql.as_ptr(),
                     len_with_nul,
                     &mut c_stmt,
-                    ptr::null_mut(),
+                    &mut c_tail,
                 )
             }
         };
+        if !c_tail.is_null() && unsafe { *c_tail == 0 } {
+            // '\0' when there is no ';' at the end
+            c_tail = ptr::null(); // TODO ignore spaces, comments, ... at the end
+        }
         self.decode_result(r)
-            .map(|_| Statement::new(conn, RawStatement::new(c_stmt)))
+            .map(|_| Statement::new(conn, RawStatement::new(c_stmt, c_tail)))
     }
 
     fn changes(&mut self) -> usize {
@@ -1238,6 +1249,20 @@ mod test {
         let err = db.execute("SELECT 1 WHERE 1 < ?", &[&1i32]).unwrap_err();
         match err {
             Error::ExecuteReturnedResults => (),
+            _ => panic!("Unexpected error: {}", err),
+        }
+    }
+
+    #[test]
+    fn test_execute_multiple() {
+        let db = checked_memory_handle();
+        let err = db
+            .execute(
+                "CREATE TABLE foo(x INTEGER); CREATE TABLE foo(x INTEGER)",
+                &[],
+            ).unwrap_err();
+        match err {
+            Error::MultipleStatement => (),
             _ => panic!("Unexpected error: {}", err),
         }
     }

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -1,16 +1,16 @@
 use super::ffi;
 use super::unlock_notify;
 use std::ffi::CStr;
-use std::os::raw::c_int;
+use std::os::raw::{c_char, c_int};
 use std::ptr;
 
 // Private newtype for raw sqlite3_stmts that finalize themselves when dropped.
 #[derive(Debug)]
-pub struct RawStatement(*mut ffi::sqlite3_stmt);
+pub struct RawStatement(*mut ffi::sqlite3_stmt, *const c_char);
 
 impl RawStatement {
-    pub fn new(stmt: *mut ffi::sqlite3_stmt) -> RawStatement {
-        RawStatement(stmt)
+    pub fn new(stmt: *mut ffi::sqlite3_stmt, tail: *const c_char) -> RawStatement {
+        RawStatement(stmt, tail)
     }
 
     pub unsafe fn ptr(&self) -> *mut ffi::sqlite3_stmt {
@@ -99,6 +99,10 @@ impl RawStatement {
                 Some(CStr::from_ptr(ptr))
             }
         }
+    }
+
+    pub fn has_tail(&self) -> bool {
+        !self.1.is_null()
     }
 }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -510,7 +510,7 @@ impl<'conn> Statement<'conn> {
     }
 
     fn finalize_(&mut self) -> Result<()> {
-        let mut stmt = RawStatement::new(ptr::null_mut());
+        let mut stmt = RawStatement::new(ptr::null_mut(), ptr::null());
         mem::swap(&mut stmt, &mut self.stmt);
         self.conn.decode_result(stmt.finalize())
     }
@@ -538,11 +538,19 @@ impl<'conn> Statement<'conn> {
                 .map(|s| str::from_utf8_unchecked(s.to_bytes()))
         }
     }
+
+    pub(crate) fn check_no_tail(&self) -> Result<()> {
+        if self.stmt.has_tail() {
+            Err(Error::MultipleStatement)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<'conn> Into<RawStatement> for Statement<'conn> {
     fn into(mut self) -> RawStatement {
-        let mut stmt = RawStatement::new(ptr::null_mut());
+        let mut stmt = RawStatement::new(ptr::null_mut(), ptr::null());
         mem::swap(&mut stmt, &mut self.stmt);
         stmt
     }


### PR DESCRIPTION
Impacted:
Connection.execute
Connection.execute_named
Connection.quer_row
Connection.quer_row_named

TODO:
* ignore comments, spaces at the end...
* behind a specific feature?
