### PR TITLE
Add query/execute functions taking `&[impl ToSql]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,34 @@ impl Connection {
             .and_then(|mut stmt| stmt.execute_named(params))
     }
 
+    /// Convenience method to prepare and execute a single SQL statement with
+    /// a list of parameters which are all the same type (see also
+    /// `Statement::execute_static`).
+    ///
+    /// On success, returns the number of rows that were changed or inserted or
+    /// deleted (via `sqlite3_changes`).
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result};
+    /// fn insert(conn: &Connection) -> Result<usize> {
+    ///     conn.execute_static(
+    ///         "INSERT INTO test (name) VALUES (:name)",
+    ///         &["one"],
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `sql` cannot be converted to a C-compatible string
+    /// or if the underlying SQLite call fails.
+    pub fn execute_static(&self, sql: &str, params: &[impl ToSql]) -> Result<usize> {
+        self.prepare(sql)
+            .and_then(|mut stmt| stmt.execute_static(params))
+    }
+
     /// Get the SQLite rowid of the most recent successful INSERT.
     ///
     /// Uses [sqlite3_last_insert_rowid](https://www.sqlite.org/c3ref/last_insert_rowid.html) under


### PR DESCRIPTION
This is especially useful when generating queries that do bulk select/insert/update operations, as otherwise you often need to map to a secondary vector, which is annoying. It also can cause you to have additional borrows out on things you'd rather not, which can cause some minor headaches.

These functions also avoids the combination trait dispatch + enum dispatch when querying with a `Value`, which is nice but probably doesn't matter in practice given that the overhead from executing the query is likely higher.

I didn't add versions for `_named_static`, both because it seems a lot less useful to me, and to avoid the combinatorial explosion of query variants.

I also didn't add a `query_row_static` because it doesn't seem that useful to me, but I can if you think it's worth doing (even if just for consistency).

Note: I'm not tied to the name of these functions at all. I actually don't think the name `_static` is *that* clear (it refers to static dispatch here, but static can mean a lot of things), but it's the best I could come up with -- I'm open to suggestions.