### PR TITLE
Add a feature for storing i128 as blobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
   - cargo test --features serde_json
   - cargo test --features bundled
   - cargo test --features sqlcipher
+  - cargo test --features i128_blob
   - cargo test --features "unlock_notify bundled"
   - cargo test --features "array bundled csvtab vtab"
   - cargo test --features "backup blob chrono csvtab functions hooks limits load_extension serde_json trace vtab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bundled = ["libsqlite3-sys/bundled"]
 buildtime_bindgen = ["libsqlite3-sys/buildtime_bindgen"]
 limits = []
 hooks = []
+i128_blob = ["byteorder"]
 sqlcipher = ["libsqlite3-sys/sqlcipher"]
 unlock_notify = ["libsqlite3-sys/unlock_notify"]
 # xSavepoint, xRelease and xRollbackTo: 3.7.7 (2011-06-23)
@@ -48,6 +49,7 @@ chrono = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.0", optional = true }
 lazy_static = { version = "1.0", optional = true }
+byteorder = { version = "1.2", features = ["i128"], optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 * `vtab` for [virtual table](https://sqlite.org/vtab.html) support (allows you to write virtual table implemntations in Rust). Currently, only read-only virtual tables are supported.
 * [`csvtab`](https://sqlite.org/csv.html), CSV virtual table written in Rust.
 * [`array`](https://sqlite.org/carray.html), The `rarray()` Table-Valued Function.
+* `i128_blob` allows storing values of type `i128` type in SQLite databases. Internally, the data is stored as a 16 byte big-endian blob, with the most significant bit flipped, which allows ordering and comparison between different blobs storing i128s to work as expected.
 
 ## Notes on building rusqlite and libsqlite3-sys
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(feature = "i128_blob")]
+extern crate byteorder;
+
 use std::cell::RefCell;
 use std::convert;
 use std::default::Default;

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -59,6 +59,12 @@ from_value!(u32);
 from_value!(f64);
 from_value!(Vec<u8>);
 
+// It would be nice if we could avoid the heap allocation (of the `Vec`) that
+// `i128` needs in `Into<Value>`, but it's probably fine for the moment, and not
+// worth adding another case to Value.
+#[cfg(feature = "i128_blob")]
+from_value!(i128);
+
 impl<'a> ToSql for ToSqlOutput<'a> {
     fn to_sql(&self) -> Result<ToSqlOutput> {
         Ok(match *self {
@@ -111,6 +117,9 @@ to_sql_self!(u8);
 to_sql_self!(u16);
 to_sql_self!(u32);
 to_sql_self!(f64);
+
+#[cfg(feature = "i128_blob")]
+to_sql_self!(i128);
 
 impl<'a, T: ?Sized> ToSql for &'a T
 where
@@ -193,5 +202,39 @@ mod test {
         let cow = Cow::Owned::<str>(String::from(s));
         let r = cow.to_sql();
         assert!(r.is_ok());
+    }
+
+    #[cfg(feature = "i128_blob")]
+    #[test]
+    fn test_i128() {
+        use {Connection, NO_PARAMS};
+        use std::i128;
+        let db = Connection::open_in_memory().unwrap();
+        db.execute_batch("CREATE TABLE foo (i128 BLOB, desc TEXT)").unwrap();
+        db.execute("
+            INSERT INTO foo(i128, desc) VALUES
+                (?, 'zero'),
+                (?, 'neg one'), (?, 'neg two'),
+                (?, 'pos one'), (?, 'pos two'),
+                (?, 'min'), (?, 'max')",
+            &[0i128, -1i128, -2i128, 1i128, 2i128, i128::MIN, i128::MAX]
+        ).unwrap();
+
+        let mut stmt = db.prepare("SELECT i128, desc FROM foo ORDER BY i128 ASC").unwrap();
+
+        let res = stmt.query_map(
+            NO_PARAMS,
+            |row| (row.get::<_, i128>(0), row.get::<_, String>(1))
+        ).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert_eq!(res, &[
+            (i128::MIN, "min".to_owned()),
+            (-2, "neg two".to_owned()),
+            (-1, "neg one".to_owned()),
+            (0, "zero".to_owned()),
+            (1, "pos one".to_owned()),
+            (2, "pos two".to_owned()),
+            (i128::MAX, "max".to_owned()),
+        ]);
     }
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -36,6 +36,18 @@ impl From<isize> for Value {
     }
 }
 
+#[cfg(feature = "i128_blob")]
+impl From<i128> for Value {
+    fn from(i: i128) -> Value {
+        use byteorder::{BigEndian, ByteOrder};
+        let mut buf = vec![0u8; 16];
+        // We store these biased (e.g. with the most significant bit flipped)
+        // so that comparisons with negative numbers work properly.
+        BigEndian::write_i128(&mut buf, i ^ (1i128 << 127));
+        Value::Blob(buf)
+    }
+}
+
 macro_rules! from_i64(
     ($t:ty) => (
         impl From<$t> for Value {


### PR DESCRIPTION
Note: I couldn't figure out how to unify this with the https://github.com/jgallagher/rusqlite/pull/392 PR, or even if that is a good thing; it's code is substantially different anyway (Apologies either way). Regardless, most of the differences are due to the fact that I agree with the comments at https://github.com/jgallagher/rusqlite/pull/392#issuecomment-424089697.

This is behind the `i128_blob` feature.

Blobs are stored as 16 byte big-endian values, with their most significant bit flipped. This is so that sorting, comparison, etc all work properly, even with negative numbers. This also allows the representation to be stable across different computers.

It's possible that the `FromSql` implementation should handle the case that the real value is stored in an integer. I didn't do this, but would be willing to make the change. I don't think we should store them this way though (e.g. IMO `ToSql` shouldn't work like this), since I don't think users would be able to sort/compare them sanely.

Support for `u128` is not implemented, as comparison with `i128` values would work strangely. This also is consistent with `u64` not being allowed, not that I think that would be reason enough on it's own.

The `byteorder` crate is used if this feature is flipped, as it's quite small and implements things more or less optimally. If/when `i128::{to,from}_be_bytes` gets stabilized (https://github.com/rust-lang/rust/issues/52963), we should probably use that instead.