### PR TITLE
Allow getting a ValueRef out of Row and Context, fixes #259

### DIFF
--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -52,7 +52,7 @@ impl<'a> ValueRef<'a> {
 
     /// If `self` is case `Text`, returns the string value. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_str(&self) -> FromSqlResult<&str> {
+    pub fn as_str(&self) -> FromSqlResult<&'a str> {
         match *self {
             ValueRef::Text(t) => Ok(t),
             _ => Err(FromSqlError::InvalidType),
@@ -61,7 +61,7 @@ impl<'a> ValueRef<'a> {
 
     /// If `self` is case `Blob`, returns the byte slice. Otherwise, returns
     /// `Err(Error::InvalidColumnType)`.
-    pub fn as_blob(&self) -> FromSqlResult<&[u8]> {
+    pub fn as_blob(&self) -> FromSqlResult<&'a [u8]> {
         match *self {
             ValueRef::Blob(b) => Ok(b),
             _ => Err(FromSqlError::InvalidType),


### PR DESCRIPTION
This takes approach 3 in #259, specifically letting rusqlite return a `ValueRef` from `Row` and `Context` (for my case I care more about `Context` than with `Row`, but in the past I've certainly wanted both). This seems the simplest and most straightforward to me, and I don't really think I see the benefit of trying to make this more generic/flexible, although if you have a concrete suggestion I'm open.

I don't have an opinion on the name `get_raw`, I picked it only because I needed this feature, and it was just the name suggested in #259. It doesn't seem great since it sort of implies unsafety (and it's completely safe), but something like `get_ref` feels like it should be higher level than this is. But again, I don't really care about the name here.

Anyway, this changes a few lifetime bounds:

- The data returned by `ValueRef<'a>`'s `as_str()`/`as_blob()` is bound to `'a` (this just seems like an accident to me that it wasn't, you could already get this as `'a` if you did the match yourself). Without this, `a.get_raw().as_str()` doesn't work.

- `Row<'a, 'stmt>` now requires the `'stmt` outlives `'a`, because we need to return `ValueRef<'a>` from the Row (`ValueRef<'stmt>`, which `stmt.value_ref()` returns, would be allowed to live past calls to `sqlite3_step`, which is bad).

Using `thing.get_raw().as_{str,blob}()` is seems ergonomic enough, but the lack of an automatic conversion from `FromSqlError` (returned by as_str/blob) to `rusqlite::Error` does make this less ergonomic. This is the part of the patch I'm least happy with, but I wasn't completely sure what the best approach for this would be.