### PR TITLE
Make the `libsqlite3_sys as ffi` export `pub`

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,7 +14,6 @@
 //! ## Example
 //!
 //! ```rust
-//! extern crate libsqlite3_sys;
 //! extern crate rusqlite;
 //!
 //! use rusqlite::blob::ZeroBlob;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -9,7 +9,6 @@
 //! module.
 //!
 //! ```rust
-//! extern crate libsqlite3_sys;
 //! extern crate rusqlite;
 //! extern crate regex;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! ```
 #![allow(unknown_lints)]
 
-use libsqlite3_sys as ffi;
+pub use libsqlite3_sys as ffi;
 
 #[macro_use]
 extern crate bitflags;

--- a/tests/deny_single_threaded_sqlite_config.rs
+++ b/tests/deny_single_threaded_sqlite_config.rs
@@ -1,8 +1,7 @@
 //! Ensure we reject connections when SQLite is in single-threaded mode, as it
 //! would violate safety if multiple Rust threads tried to use connections.
 
-use libsqlite3_sys as ffi;
-
+use rusqlite::ffi;
 use rusqlite::Connection;
 
 #[test]


### PR DESCRIPTION
It's a pain to figure out what the required version of this is for cases where you need it (and causes build problems if you get it wrong), it would be better if it were just exposed publicly.