### PR TITLE
Derive Debug for Transaction

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -556,6 +556,16 @@ mod test {
         assert_current_sum(8, &db);
     }
 
+    #[test]
+    fn test_rc() {
+        use std::rc::Rc;
+        let mut conn = Connection::open_in_memory().unwrap();
+        let rc_txn = Rc::new(conn.transaction().unwrap());
+
+        // This will compile only if Transaction is Debug
+        Rc::try_unwrap(rc_txn).unwrap();
+    }
+
     fn insert(x: i32, conn: &Connection) {
         conn.execute("INSERT INTO foo VALUES(?)", &[x]).unwrap();
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -11,7 +11,7 @@ pub enum TransactionBehavior {
 }
 
 /// Options for how a Transaction or Savepoint should behave when it is dropped.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DropBehavior {
     /// Roll back the changes. This is the default.
     Rollback,
@@ -50,6 +50,7 @@ pub enum DropBehavior {
 ///     tx.commit()
 /// }
 /// ```
+#[derive(Debug)]
 pub struct Transaction<'conn> {
     conn: &'conn Connection,
     drop_behavior: DropBehavior,


### PR DESCRIPTION
It seems you can't `unwrap()` an `Ok(Transaction)` (produced in my case by `Rc::try_unwrap()` unless `Transaction` is `Debug`.