### PR TITLE
Add params/named_params macro, and expose ToSql from top level

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -112,6 +112,17 @@ impl<'conn> Statement<'conn> {
     /// }
     /// ```
     ///
+    /// Note, the `named_params` macro is provided for syntactic convenience, and
+    /// so the above example could also be written as:
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result, named_params};
+    /// fn insert(conn: &Connection) -> Result<usize> {
+    ///     let mut stmt = conn.prepare("INSERT INTO test (name) VALUES (:name)")?;
+    ///     stmt.execute_named(named_params!{":name": "one"})
+    /// }
+    /// ```
+    ///
     /// # Failure
     ///
     /// Will return `Err` if binding parameters fails, the executed statement
@@ -198,6 +209,21 @@ impl<'conn> Statement<'conn> {
     /// fn query(conn: &Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test where name = :name")?;
     ///     let mut rows = stmt.query_named(&[(":name", &"one")])?;
+    ///     while let Some(row) = rows.next() {
+    ///         // ...
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Note, the `named_params!` macro is provided for syntactic convenience, and
+    /// so the above example could also be written as:
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result, named_params};
+    /// fn query(conn: &Connection) -> Result<()> {
+    ///     let mut stmt = conn.prepare("SELECT * FROM test where name = :name")?;
+    ///     let mut rows = stmt.query_named(named_params!{ ":name": "one" })?;
     ///     while let Some(row) = rows.next() {
     ///         // ...
     ///     }


### PR DESCRIPTION
Nobody asked for `named_params!`, but it would be nice. It would be nicer if it were supported as the params! macro, but doing that would require a lot more work (see https://github.com/serde-rs/json/blob/master/src/macros.rs, for example).

I've also made some of the examples and tests use this, although not all of them as the intent isn't to deprecate passing these explicitly, just to make doing it more convenient.

Re-exposing ToSql from the top level is done just to make it more obvious. It's a fairly important part of the API, and it feels buried for it to live in `rusqlite::types::`.

Fixes #462.