### PR TITLE
Clean examples

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,8 +14,6 @@
 //! ## Example
 //!
 //! ```rust
-//! extern crate rusqlite;
-//!
 //! use rusqlite::blob::ZeroBlob;
 //! use rusqlite::{Connection, DatabaseName, NO_PARAMS};
 //! use std::io::{Read, Seek, SeekFrom, Write};

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -9,9 +9,6 @@
 //! module.
 //!
 //! ```rust
-//! extern crate rusqlite;
-//! extern crate regex;
-//!
 //! use regex::Regex;
 //! use rusqlite::{Connection, Error, Result, NO_PARAMS};
 //! use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,8 @@
 //! expose an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).
 //!
 //! ```rust
-//! extern crate rusqlite;
-//! extern crate time;
-//!
 //! use rusqlite::types::ToSql;
-//! use rusqlite::{Connection, params};
+//! use rusqlite::{params, Connection};
 //! use time::Timespec;
 //!
 //! #[derive(Debug)]
@@ -145,7 +142,6 @@ pub mod vtab;
 const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 /// To be used when your statement has no [parameter](https://sqlite.org/lang_expr.html#varparam).
 pub const NO_PARAMS: &[&dyn ToSql] = &[];
-
 
 /// A macro making it more convenient to pass heterogeneous lists
 /// of parameters as a `&[&dyn ToSql]`.
@@ -1715,12 +1711,7 @@ mod test {
         let mut insert_stmt = db.prepare("INSERT INTO foo(i, x) VALUES(?, ?)").unwrap();
         for (i, v) in vals.iter().enumerate() {
             let i_to_insert = i as i64;
-            assert_eq!(
-                insert_stmt
-                    .execute(params![i_to_insert, v])
-                    .unwrap(),
-                1
-            );
+            assert_eq!(insert_stmt.execute(params![i_to_insert, v]).unwrap(), 1);
         }
 
         let mut query = db.prepare("SELECT i, x FROM foo").unwrap();

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -112,8 +112,8 @@ impl<'conn> Statement<'conn> {
     /// }
     /// ```
     ///
-    /// Note, the `named_params` macro is provided for syntactic convenience, and
-    /// so the above example could also be written as:
+    /// Note, the `named_params` macro is provided for syntactic convenience,
+    /// and so the above example could also be written as:
     ///
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result, named_params};
@@ -216,8 +216,8 @@ impl<'conn> Statement<'conn> {
     /// }
     /// ```
     ///
-    /// Note, the `named_params!` macro is provided for syntactic convenience, and
-    /// so the above example could also be written as:
+    /// Note, the `named_params!` macro is provided for syntactic convenience,
+    /// and so the above example could also be written as:
     ///
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result, named_params};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,9 +19,6 @@
 //! store timespecs as `f64`s:
 //!
 //! ```rust
-//! extern crate rusqlite;
-//! extern crate time;
-//!
 //! use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 //! use rusqlite::Result;
 //!
@@ -77,7 +74,6 @@ mod value_ref;
 /// ## Example
 ///
 /// ```rust,no_run
-/// # extern crate rusqlite;
 /// # use rusqlite::{Connection, Result};
 /// # use rusqlite::types::{Null};
 /// fn main() {}


### PR DESCRIPTION
Remove `extern crate` usages.
Rustfmt.