### PR TITLE
Clarify instruction for building with vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ You can adjust this behavior in a number of ways:
   which must be enabled by setting `VCPKGRS_DYNAMIC=1` environment variable before build.
   `vcpkg install sqlite3:x64-windows` will install the required library.
   
-*Note:* to change the way `libsqlite3-sys` is built, you need to run `cargo clean libsqlite3-sys` first.
-  
 ### Binding generation
 
 We use [bindgen](https://crates.io/crates/bindgen) to generate the Rust

--- a/README.md
+++ b/README.md
@@ -128,8 +128,12 @@ You can adjust this behavior in a number of ways:
 * Installing the sqlite3 development packages will usually be all that is required, but
   the build helpers for [pkg-config](https://github.com/alexcrichton/pkg-config-rs)
   and [vcpkg](https://github.com/mcgoo/vcpkg-rs) have some additional configuration
-  options. The default when using vcpkg is to dynamically link. `vcpkg install sqlite3:x64-windows` will install the required library.
-
+  options. The default when using vcpkg is to dynamically link,
+  which must be enabled by setting `VCPKGRS_DYNAMIC=1` environment variable before build.
+  `vcpkg install sqlite3:x64-windows` will install the required library.
+  
+*Note:* to change the way `libsqlite3-sys` is built, you need to run `cargo clean libsqlite3-sys` first.
+  
 ### Binding generation
 
 We use [bindgen](https://crates.io/crates/bindgen) to generate the Rust

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -132,6 +132,9 @@ mod build {
         if cfg!(target_os = "windows") {
             println!("cargo:rerun-if-env-changed=PATH");
         }
+        if cfg!(all(feature = "vcpkg", target_env = "msvc")) {
+            println!("cargo:rerun-if-env-changed=VCPKGRS_DYNAMIC");
+        }
         // Allow users to specify where to find SQLite.
         if let Ok(dir) = env::var(format!("{}_LIB_DIR", env_prefix())) {
             // Try to use pkg-config to determine link commands


### PR DESCRIPTION
Mention `VCPKGRS_DYNAMIC=1` environment variable,
and the fact that you need to run `cargo clean` in order to force rebuild. 