### PR TITLE
Do not panic by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ fn main() -> Result<()> {
     let mut stmt = conn
         .prepare("SELECT id, name, time_created, data FROM person")?;
     let person_iter = stmt
-        .query_map(NO_PARAMS, |row| Person {
-            id: row.get(0),
-            name: row.get(1),
-            time_created: row.get(2),
-            data: row.get(3),
-        })?;
+        .query_map(NO_PARAMS, |row| Ok(Person {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            time_created: row.get(2)?,
+            data: row.get(3)?,
+        }))?;
 
     for person in person_iter {
         println!("Found person {:?}", person.unwrap());

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -28,8 +28,7 @@
 //!     )?;
 //!
 //!     let rowid = db.last_insert_rowid();
-//!     let mut blob = db
-//!         .blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+//!     let mut blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
 //!
 //!     // Make sure to test that the number of bytes written matches what you expect;
 //!     // if you try to write too much, the data will be truncated to the size of the

--- a/src/busy.rs
+++ b/src/busy.rs
@@ -82,7 +82,7 @@ mod test {
     use std::time::Duration;
     use tempdir;
 
-    use crate::{Connection, Error, ErrorCode, TransactionBehavior, NO_PARAMS};
+    use crate::{Connection, Error, ErrorCode, Result, TransactionBehavior, NO_PARAMS};
 
     #[test]
     fn test_default_busy() {
@@ -94,7 +94,7 @@ mod test {
             .transaction_with_behavior(TransactionBehavior::Exclusive)
             .unwrap();
         let db2 = Connection::open(&path).unwrap();
-        let r = db2.query_row("PRAGMA schema_version", NO_PARAMS, |_| unreachable!());
+        let r: Result<()> = db2.query_row("PRAGMA schema_version", NO_PARAMS, |_| unreachable!());
         match r.unwrap_err() {
             Error::SqliteFailure(err, _) => {
                 assert_eq!(err.code, ErrorCode::DatabaseBusy);
@@ -127,7 +127,7 @@ mod test {
         assert_eq!(tx.recv().unwrap(), 1);
         let _ = db2
             .query_row("PRAGMA schema_version", NO_PARAMS, |row| {
-                row.get_checked::<_, i32>(0)
+                row.get::<_, i32>(0)
             })
             .expect("unexpected error");
 
@@ -166,7 +166,7 @@ mod test {
         assert_eq!(tx.recv().unwrap(), 1);
         let _ = db2
             .query_row("PRAGMA schema_version", NO_PARAMS, |row| {
-                row.get_checked::<_, i32>(0)
+                row.get::<_, i32>(0)
             })
             .expect("unexpected error");
         assert_eq!(CALLED.load(Ordering::Relaxed), true);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -298,7 +298,7 @@ mod test {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(
                 (1i32, 2i32),
-                stmt.query_map(NO_PARAMS, |r| (r.get(0), r.get(1)))
+                stmt.query_map(NO_PARAMS, |r| Ok((r.get(0)?, r.get(1)?)))
                     .unwrap()
                     .next()
                     .unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,12 +25,18 @@ pub enum DbConfig {
 impl Connection {
     /// Returns the current value of a `config`.
     ///
-    /// - SQLITE_DBCONFIG_ENABLE_FKEY: return `false` or `true` to indicate whether FK enforcement is off or on
-    /// - SQLITE_DBCONFIG_ENABLE_TRIGGER: return `false` or `true` to indicate whether triggers are disabled or enabled
-    /// - SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER: return `false` or `true` to indicate whether fts3_tokenizer are disabled or enabled
-    /// - SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE: return `false` to indicate checkpoints-on-close are not disabled or `true` if they are
-    /// - SQLITE_DBCONFIG_ENABLE_QPSG: return `false` or `true` to indicate whether the QPSG is disabled or enabled
-    /// - SQLITE_DBCONFIG_TRIGGER_EQP: return `false` to indicate output-for-trigger are not disabled or `true` if it is
+    /// - SQLITE_DBCONFIG_ENABLE_FKEY: return `false` or `true` to indicate
+    ///   whether FK enforcement is off or on
+    /// - SQLITE_DBCONFIG_ENABLE_TRIGGER: return `false` or `true` to indicate
+    ///   whether triggers are disabled or enabled
+    /// - SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER: return `false` or `true` to
+    ///   indicate whether fts3_tokenizer are disabled or enabled
+    /// - SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE: return `false` to indicate
+    ///   checkpoints-on-close are not disabled or `true` if they are
+    /// - SQLITE_DBCONFIG_ENABLE_QPSG: return `false` or `true` to indicate
+    ///   whether the QPSG is disabled or enabled
+    /// - SQLITE_DBCONFIG_TRIGGER_EQP: return `false` to indicate
+    ///   output-for-trigger are not disabled or `true` if it is
     pub fn db_config(&self, config: DbConfig) -> Result<bool> {
         let c = self.db.borrow();
         unsafe {
@@ -47,12 +53,18 @@ impl Connection {
 
     /// Make configuration changes to a database connection
     ///
-    /// - SQLITE_DBCONFIG_ENABLE_FKEY: `false` to disable FK enforcement, `true` to enable FK enforcement
-    /// - SQLITE_DBCONFIG_ENABLE_TRIGGER: `false` to disable triggers, `true` to enable triggers
-    /// - SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER: `false` to disable fts3_tokenizer(), `true` to enable fts3_tokenizer()
-    /// - SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE: `false` (the default) to enable checkpoints-on-close, `true` to disable them
-    /// - SQLITE_DBCONFIG_ENABLE_QPSG: `false` to disable the QPSG, `true` to enable QPSG
-    /// - SQLITE_DBCONFIG_TRIGGER_EQP: `false` to disable output for trigger programs, `true` to enable it
+    /// - SQLITE_DBCONFIG_ENABLE_FKEY: `false` to disable FK enforcement, `true`
+    ///   to enable FK enforcement
+    /// - SQLITE_DBCONFIG_ENABLE_TRIGGER: `false` to disable triggers, `true` to
+    ///   enable triggers
+    /// - SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER: `false` to disable
+    ///   fts3_tokenizer(), `true` to enable fts3_tokenizer()
+    /// - SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE: `false` (the default) to enable
+    ///   checkpoints-on-close, `true` to disable them
+    /// - SQLITE_DBCONFIG_ENABLE_QPSG: `false` to disable the QPSG, `true` to
+    ///   enable QPSG
+    /// - SQLITE_DBCONFIG_TRIGGER_EQP: `false` to disable output for trigger
+    ///   programs, `true` to enable it
     pub fn set_db_config(&self, config: DbConfig, new_val: bool) -> Result<bool> {
         let c = self.db.borrow_mut();
         unsafe {
@@ -78,11 +90,25 @@ mod test {
         let db = Connection::open_in_memory().unwrap();
 
         let opposite = !db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY).unwrap();
-        assert_eq!(db.set_db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY, opposite), Ok(opposite));
-        assert_eq!(db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY), Ok(opposite));
+        assert_eq!(
+            db.set_db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY, opposite),
+            Ok(opposite)
+        );
+        assert_eq!(
+            db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY),
+            Ok(opposite)
+        );
 
-        let opposite = !db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER).unwrap();
-        assert_eq!(db.set_db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER, opposite), Ok(opposite));
-        assert_eq!(db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER), Ok(opposite));
+        let opposite = !db
+            .db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER)
+            .unwrap();
+        assert_eq!(
+            db.set_db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER, opposite),
+            Ok(opposite)
+        );
+        assert_eq!(
+            db.db_config(DbConfig::SQLITE_DBCONFIG_ENABLE_TRIGGER),
+            Ok(opposite)
+        );
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -38,12 +38,11 @@
 //!     let db = Connection::open_in_memory()?;
 //!     add_regexp_function(&db)?;
 //!
-//!     let is_match: bool = db
-//!         .query_row(
-//!             "SELECT regexp('[aeiou]*', 'aaaaeeeiii')",
-//!             NO_PARAMS,
-//!             |row| row.get(0),
-//!         )?;
+//!     let is_match: bool = db.query_row(
+//!         "SELECT regexp('[aeiou]*', 'aaaaeeeiii')",
+//!         NO_PARAMS,
+//!         |row| row.get(0),
+//!     )?;
 //!
 //!     assert!(is_match);
 //!     Ok(())
@@ -771,7 +770,7 @@ mod test {
         let dual_sum = "SELECT my_sum(i), my_sum(j) FROM (SELECT 2 AS i, 1 AS j UNION ALL SELECT \
                         2, 1)";
         let result: (i64, i64) = db
-            .query_row(dual_sum, NO_PARAMS, |r| (r.get(0), r.get(1)))
+            .query_row(dual_sum, NO_PARAMS, |r| Ok((r.get(0)?, r.get(1)?)))
             .unwrap();
         assert_eq!((4, 2), result);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,15 +38,15 @@
 //!         params![me.name, me.time_created, me.data],
 //!     )?;
 //!
-//!     let mut stmt = conn
-//!         .prepare("SELECT id, name, time_created, data FROM person")?;
-//!     let person_iter = stmt
-//!         .query_map(params![], |row| Person {
-//!             id: row.get(0),
-//!             name: row.get(1),
-//!             time_created: row.get(2),
-//!             data: row.get(3),
-//!         })?;
+//!     let mut stmt = conn.prepare("SELECT id, name, time_created, data FROM person")?;
+//!     let person_iter = stmt.query_map(params![], |row| {
+//!         Ok(Person {
+//!             id: row.get(0)?,
+//!             name: row.get(1)?,
+//!             time_created: row.get(2)?,
+//!             data: row.get(3)?,
+//!         })
+//!     })?;
 //!
 //!     for person in person_iter {
 //!         println!("Found person {:?}", person.unwrap());
@@ -473,7 +473,7 @@ impl Connection {
     where
         P: IntoIterator,
         P::Item: ToSql,
-        F: FnOnce(&Row<'_, '_>) -> T,
+        F: FnOnce(&Row<'_, '_>) -> Result<T>,
     {
         let mut stmt = self.prepare(sql)?;
         stmt.query_row(params, f)
@@ -495,12 +495,12 @@ impl Connection {
     /// or if the underlying SQLite call fails.
     pub fn query_row_named<T, F>(&self, sql: &str, params: &[(&str, &dyn ToSql)], f: F) -> Result<T>
     where
-        F: FnOnce(&Row<'_, '_>) -> T,
+        F: FnOnce(&Row<'_, '_>) -> Result<T>,
     {
         let mut stmt = self.prepare(sql)?;
         let mut rows = stmt.query_named(params)?;
 
-        rows.get_expected_row().map(|r| f(&r))
+        rows.get_expected_row().and_then(|r| f(&r))
     }
 
     /// Convenience method to execute a query that is expected to return a
@@ -516,7 +516,7 @@ impl Connection {
     ///     conn.query_row_and_then(
     ///         "SELECT value FROM preferences WHERE name='locale'",
     ///         NO_PARAMS,
-    ///         |row| row.get_checked(0),
+    ///         |row| row.get(0),
     ///     )
     /// }
     /// ```
@@ -858,9 +858,9 @@ mod test {
             let tx2 = db2.transaction().unwrap();
 
             // SELECT first makes sqlite lock with a shared lock
-            tx1.query_row("SELECT x FROM foo LIMIT 1", NO_PARAMS, |_| ())
+            tx1.query_row("SELECT x FROM foo LIMIT 1", NO_PARAMS, |_| Ok(()))
                 .unwrap();
-            tx2.query_row("SELECT x FROM foo LIMIT 1", NO_PARAMS, |_| ())
+            tx2.query_row("SELECT x FROM foo LIMIT 1", NO_PARAMS, |_| Ok(()))
                 .unwrap();
 
             tx1.execute("INSERT INTO foo VALUES(?1)", &[1]).unwrap();
@@ -1061,7 +1061,7 @@ mod test {
             let mut v = Vec::<i32>::new();
 
             while let Some(row) = rows.next() {
-                v.push(row.unwrap().get(0));
+                v.push(row.unwrap().get(0).unwrap());
             }
 
             assert_eq!(v, [3i32, 2, 1]);
@@ -1072,7 +1072,7 @@ mod test {
             let mut v = Vec::<i32>::new();
 
             while let Some(row) = rows.next() {
-                v.push(row.unwrap().get(0));
+                v.push(row.unwrap().get(0).unwrap());
             }
 
             assert_eq!(v, [2i32, 1]);
@@ -1125,7 +1125,7 @@ mod test {
             err => panic!("Unexpected error {}", err),
         }
 
-        let bad_query_result = db.query_row("NOT A PROPER QUERY; test123", NO_PARAMS, |_| ());
+        let bad_query_result = db.query_row("NOT A PROPER QUERY; test123", NO_PARAMS, |_| Ok(()));
 
         assert!(bad_query_result.is_err());
     }
@@ -1400,7 +1400,7 @@ mod test {
 
             let mut query = db.prepare("SELECT x, y FROM foo ORDER BY x DESC").unwrap();
             let results: Result<Vec<String>> = query
-                .query_and_then(NO_PARAMS, |row| row.get_checked(1))
+                .query_and_then(NO_PARAMS, |row| row.get(1))
                 .unwrap()
                 .collect();
 
@@ -1421,7 +1421,7 @@ mod test {
 
             let mut query = db.prepare("SELECT x, y FROM foo ORDER BY x DESC").unwrap();
             let bad_type: Result<Vec<f64>> = query
-                .query_and_then(NO_PARAMS, |row| row.get_checked(1))
+                .query_and_then(NO_PARAMS, |row| row.get(1))
                 .unwrap()
                 .collect();
 
@@ -1431,7 +1431,7 @@ mod test {
             }
 
             let bad_idx: Result<Vec<String>> = query
-                .query_and_then(NO_PARAMS, |row| row.get_checked(3))
+                .query_and_then(NO_PARAMS, |row| row.get(3))
                 .unwrap()
                 .collect();
 
@@ -1455,9 +1455,7 @@ mod test {
 
             let mut query = db.prepare("SELECT x, y FROM foo ORDER BY x DESC").unwrap();
             let results: CustomResult<Vec<String>> = query
-                .query_and_then(NO_PARAMS, |row| {
-                    row.get_checked(1).map_err(CustomError::Sqlite)
-                })
+                .query_and_then(NO_PARAMS, |row| row.get(1).map_err(CustomError::Sqlite))
                 .unwrap()
                 .collect();
 
@@ -1478,9 +1476,7 @@ mod test {
 
             let mut query = db.prepare("SELECT x, y FROM foo ORDER BY x DESC").unwrap();
             let bad_type: CustomResult<Vec<f64>> = query
-                .query_and_then(NO_PARAMS, |row| {
-                    row.get_checked(1).map_err(CustomError::Sqlite)
-                })
+                .query_and_then(NO_PARAMS, |row| row.get(1).map_err(CustomError::Sqlite))
                 .unwrap()
                 .collect();
 
@@ -1490,9 +1486,7 @@ mod test {
             }
 
             let bad_idx: CustomResult<Vec<String>> = query
-                .query_and_then(NO_PARAMS, |row| {
-                    row.get_checked(3).map_err(CustomError::Sqlite)
-                })
+                .query_and_then(NO_PARAMS, |row| row.get(3).map_err(CustomError::Sqlite))
                 .unwrap()
                 .collect();
 
@@ -1523,7 +1517,7 @@ mod test {
 
             let query = "SELECT x, y FROM foo ORDER BY x DESC";
             let results: CustomResult<String> = db.query_row_and_then(query, NO_PARAMS, |row| {
-                row.get_checked(1).map_err(CustomError::Sqlite)
+                row.get(1).map_err(CustomError::Sqlite)
             });
 
             assert_eq!(results.unwrap(), "hello");
@@ -1540,7 +1534,7 @@ mod test {
 
             let query = "SELECT x, y FROM foo ORDER BY x DESC";
             let bad_type: CustomResult<f64> = db.query_row_and_then(query, NO_PARAMS, |row| {
-                row.get_checked(1).map_err(CustomError::Sqlite)
+                row.get(1).map_err(CustomError::Sqlite)
             });
 
             match bad_type.unwrap_err() {
@@ -1549,7 +1543,7 @@ mod test {
             }
 
             let bad_idx: CustomResult<String> = db.query_row_and_then(query, NO_PARAMS, |row| {
-                row.get_checked(3).map_err(CustomError::Sqlite)
+                row.get(3).map_err(CustomError::Sqlite)
             });
 
             match bad_idx.unwrap_err() {
@@ -1576,7 +1570,8 @@ mod test {
             db.execute_batch(sql).unwrap();
 
             db.query_row("SELECT * FROM foo", params![], |r| {
-                assert_eq!(2, r.column_count())
+                assert_eq!(2, r.column_count());
+                Ok(())
             })
             .unwrap();
         }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -140,13 +140,13 @@ mod test {
         let mut db = Connection::open_in_memory().unwrap();
         db.trace(Some(tracer));
         {
-            let _ = db.query_row("SELECT ?", &[1i32], |_| {});
-            let _ = db.query_row("SELECT ?", &["hello"], |_| {});
+            let _ = db.query_row("SELECT ?", &[1i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?", &["hello"], |_| Ok(()));
         }
         db.trace(None);
         {
-            let _ = db.query_row("SELECT ?", &[2i32], |_| {});
-            let _ = db.query_row("SELECT ?", &["goodbye"], |_| {});
+            let _ = db.query_row("SELECT ?", &[2i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?", &["goodbye"], |_| Ok(()));
         }
 
         let traced_stmts = TRACED_STMTS.lock().unwrap();

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -210,8 +210,7 @@ mod test {
         {
             for n in out_of_range {
                 let err = db
-                    .query_row("SELECT ?", &[n], |r| r.get_checked::<_, T>(0))
-                    .unwrap()
+                    .query_row("SELECT ?", &[n], |r| r.get::<_, T>(0))
                     .unwrap_err();
                 match err {
                     Error::IntegralValueOutOfRange(_, value) => assert_eq!(*n, value),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -207,16 +207,16 @@ mod test {
 
         {
             let row1 = rows.next().unwrap().unwrap();
-            let s1: Option<String> = row1.get(0);
-            let b1: Option<Vec<u8>> = row1.get(1);
+            let s1: Option<String> = row1.get_unwrap(0);
+            let b1: Option<Vec<u8>> = row1.get_unwrap(1);
             assert_eq!(s.unwrap(), s1.unwrap());
             assert!(b1.is_none());
         }
 
         {
             let row2 = rows.next().unwrap().unwrap();
-            let s2: Option<String> = row2.get(0);
-            let b2: Option<Vec<u8>> = row2.get(1);
+            let s2: Option<String> = row2.get_unwrap(0);
+            let b2: Option<Vec<u8>> = row2.get_unwrap(1);
             assert!(s2.is_none());
             assert_eq!(b, b2);
         }
@@ -246,102 +246,94 @@ mod test {
         let row = rows.next().unwrap().unwrap();
 
         // check the correct types come back as expected
-        assert_eq!(vec![1, 2], row.get_checked::<_, Vec<u8>>(0).unwrap());
-        assert_eq!("text", row.get_checked::<_, String>(1).unwrap());
-        assert_eq!(1, row.get_checked::<_, c_int>(2).unwrap());
-        assert!((1.5 - row.get_checked::<_, c_double>(3).unwrap()).abs() < EPSILON);
-        assert!(row.get_checked::<_, Option<c_int>>(4).unwrap().is_none());
-        assert!(row.get_checked::<_, Option<c_double>>(4).unwrap().is_none());
-        assert!(row.get_checked::<_, Option<String>>(4).unwrap().is_none());
+        assert_eq!(vec![1, 2], row.get::<_, Vec<u8>>(0).unwrap());
+        assert_eq!("text", row.get::<_, String>(1).unwrap());
+        assert_eq!(1, row.get::<_, c_int>(2).unwrap());
+        assert!((1.5 - row.get::<_, c_double>(3).unwrap()).abs() < EPSILON);
+        assert!(row.get::<_, Option<c_int>>(4).unwrap().is_none());
+        assert!(row.get::<_, Option<c_double>>(4).unwrap().is_none());
+        assert!(row.get::<_, Option<String>>(4).unwrap().is_none());
 
         // check some invalid types
 
         // 0 is actually a blob (Vec<u8>)
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_int>(0).err().unwrap()
+            row.get::<_, c_int>(0).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_int>(0).err().unwrap()
+            row.get::<_, c_int>(0).err().unwrap()
+        ));
+        assert!(is_invalid_column_type(row.get::<_, i64>(0).err().unwrap()));
+        assert!(is_invalid_column_type(
+            row.get::<_, c_double>(0).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, i64>(0).err().unwrap()
+            row.get::<_, String>(0).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_double>(0).err().unwrap()
+            row.get::<_, time::Timespec>(0).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, String>(0).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, time::Timespec>(0).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Option<c_int>>(0).err().unwrap()
+            row.get::<_, Option<c_int>>(0).err().unwrap()
         ));
 
         // 1 is actually a text (String)
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_int>(1).err().unwrap()
+            row.get::<_, c_int>(1).err().unwrap()
+        ));
+        assert!(is_invalid_column_type(row.get::<_, i64>(1).err().unwrap()));
+        assert!(is_invalid_column_type(
+            row.get::<_, c_double>(1).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, i64>(1).err().unwrap()
+            row.get::<_, Vec<u8>>(1).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_double>(1).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Vec<u8>>(1).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Option<c_int>>(1).err().unwrap()
+            row.get::<_, Option<c_int>>(1).err().unwrap()
         ));
 
         // 2 is actually an integer
         assert!(is_invalid_column_type(
-            row.get_checked::<_, String>(2).err().unwrap()
+            row.get::<_, String>(2).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, Vec<u8>>(2).err().unwrap()
+            row.get::<_, Vec<u8>>(2).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, Option<String>>(2).err().unwrap()
+            row.get::<_, Option<String>>(2).err().unwrap()
         ));
 
         // 3 is actually a float (c_double)
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_int>(3).err().unwrap()
+            row.get::<_, c_int>(3).err().unwrap()
+        ));
+        assert!(is_invalid_column_type(row.get::<_, i64>(3).err().unwrap()));
+        assert!(is_invalid_column_type(
+            row.get::<_, String>(3).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, i64>(3).err().unwrap()
+            row.get::<_, Vec<u8>>(3).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, String>(3).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Vec<u8>>(3).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Option<c_int>>(3).err().unwrap()
+            row.get::<_, Option<c_int>>(3).err().unwrap()
         ));
 
         // 4 is actually NULL
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_int>(4).err().unwrap()
+            row.get::<_, c_int>(4).err().unwrap()
+        ));
+        assert!(is_invalid_column_type(row.get::<_, i64>(4).err().unwrap()));
+        assert!(is_invalid_column_type(
+            row.get::<_, c_double>(4).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, i64>(4).err().unwrap()
+            row.get::<_, String>(4).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, c_double>(4).err().unwrap()
+            row.get::<_, Vec<u8>>(4).err().unwrap()
         ));
         assert!(is_invalid_column_type(
-            row.get_checked::<_, String>(4).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, Vec<u8>>(4).err().unwrap()
-        ));
-        assert!(is_invalid_column_type(
-            row.get_checked::<_, time::Timespec>(4).err().unwrap()
+            row.get::<_, time::Timespec>(4).err().unwrap()
         ));
     }
 
@@ -360,19 +352,16 @@ mod test {
         let mut rows = stmt.query(NO_PARAMS).unwrap();
 
         let row = rows.next().unwrap().unwrap();
-        assert_eq!(
-            Value::Blob(vec![1, 2]),
-            row.get_checked::<_, Value>(0).unwrap()
-        );
+        assert_eq!(Value::Blob(vec![1, 2]), row.get::<_, Value>(0).unwrap());
         assert_eq!(
             Value::Text(String::from("text")),
-            row.get_checked::<_, Value>(1).unwrap()
+            row.get::<_, Value>(1).unwrap()
         );
-        assert_eq!(Value::Integer(1), row.get_checked::<_, Value>(2).unwrap());
-        match row.get_checked::<_, Value>(3).unwrap() {
+        assert_eq!(Value::Integer(1), row.get::<_, Value>(2).unwrap());
+        match row.get::<_, Value>(3).unwrap() {
             Value::Real(val) => assert!((1.5 - val).abs() < EPSILON),
             x => panic!("Invalid Value {:?}", x),
         }
-        assert_eq!(Value::Null, row.get_checked::<_, Value>(4).unwrap());
+        assert_eq!(Value::Null, row.get::<_, Value>(4).unwrap());
     }
 }

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -229,7 +229,7 @@ mod test {
 
         let res = stmt
             .query_map(NO_PARAMS, |row| {
-                (row.get::<_, i128>(0), row.get::<_, String>(1))
+                Ok((row.get::<_, i128>(0)?, row.get::<_, String>(1)?))
             })
             .unwrap()
             .collect::<Result<Vec<_>, _>>()

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -389,7 +389,7 @@ mod test {
 
             let mut rows = s.query(NO_PARAMS).unwrap();
             let row = rows.next().unwrap().unwrap();
-            assert_eq!(row.get::<_, i32>(0), 2);
+            assert_eq!(row.get_unwrap::<_, i32>(0), 2);
         }
         db.execute_batch("DROP TABLE vtab").unwrap();
     }


### PR DESCRIPTION
BREAKING CHANGES:
Replace `Row::get` by `Row::get_checked`,
And rename original `Row::get` to `Row::get_unwrap`.
`Stmt::query_map`, `Stmt::query_map_named`, `Stmt::query_row`,
`Conn::query_row` and `Conn::query_row_named` callback parameter must return a `Result`.