### PR TITLE
Add peekable to Rows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use crate::ffi::ErrorCode;
 pub use crate::hooks::*;
 #[cfg(feature = "load_extension")]
 pub use crate::load_extension_guard::LoadExtensionGuard;
-pub use crate::row::{AndThenRows, MappedRows, Row, RowIndex, Rows};
+pub use crate::row::{AndThenRows, MappedRows, Peekable, Row, RowIndex, Rows};
 pub use crate::statement::{Statement, StatementStatus};
 pub use crate::transaction::{DropBehavior, Savepoint, Transaction, TransactionBehavior};
 pub use crate::types::ToSql;


### PR DESCRIPTION
I couldn't find a way to peek at the next row without advancing the `Rows` iterator outside the crate, so I thought I'd submit this PR to expose this functionality.