### PR TITLE
Add Error::from_column,from_function_param

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -173,6 +173,14 @@ impl Error {
             _ => Error::from_column(err, idx, data_type),
         }
     }
+
+    #[cfg(feature = "vtab")]
+    pub fn from_filter_param(err: FromSqlError, idx: usize, data_type: Type) -> Error {
+        match err {
+            FromSqlError::InvalidType => Error::InvalidFilterParameterType(idx, data_type),
+            _ => Error::from_column(err, idx, data_type),
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,8 @@ impl From<::std::ffi::NulError> for Error {
 }
 
 impl Error {
+    /// Convert a `FromSqlError` into an `Error` for the specified column index
+    /// and type
     pub fn from_column(err: FromSqlError, idx: usize, data_type: Type) -> Error {
         match err {
             FromSqlError::InvalidType => Error::InvalidColumnType(idx, data_type),
@@ -166,6 +168,8 @@ impl Error {
         }
     }
 
+    /// Convert a `FromSqlError` into an `Error` for the specified function
+    /// parameter index and type
     #[cfg(feature = "functions")]
     pub fn from_function_param(err: FromSqlError, idx: usize, data_type: Type) -> Error {
         match err {
@@ -174,6 +178,8 @@ impl Error {
         }
     }
 
+    /// Convert a `FromSqlError` into an `Error` for the specified filter
+    /// parameter index and type
     #[cfg(feature = "vtab")]
     pub fn from_filter_param(err: FromSqlError, idx: usize, data_type: Type) -> Error {
         match err {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -928,14 +928,14 @@ mod test {
     fn test_query_row_get_raw() {
         use crate::types::Type;
         let db = Connection::open_in_memory().unwrap();
-        let mut stmt = db.prepare("SELECT X'00010001'").unwrap();
+        let mut stmt = db.prepare("SELECT X'53514C697465'").unwrap();
         let y: Result<Vec<u8>> = stmt.query_row(NO_PARAMS, |r| {
             r.get_raw_checked(0)?
                 .as_blob()
                 .map_err(|err| Error::from_column(err, 0, Type::Blob))
                 .map(|blob| blob.to_vec())
         });
-        assert_eq!(b"0101", y.unwrap().as_slice());
+        assert_eq!(b"SQLite", y.unwrap().as_slice());
     }
 
     #[test]

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -925,6 +925,20 @@ mod test {
     }
 
     #[test]
+    fn test_query_row_get_raw() {
+        use crate::types::Type;
+        let db = Connection::open_in_memory().unwrap();
+        let mut stmt = db.prepare("SELECT X'00010001'").unwrap();
+        let y: Result<Vec<u8>> = stmt.query_row(NO_PARAMS, |r| {
+            r.get_raw_checked(0)?
+                .as_blob()
+                .map_err(|err| Error::from_column(err, 0, Type::Blob))
+                .map(|blob| blob.to_vec())
+        });
+        assert_eq!(b"0101", y.unwrap().as_slice());
+    }
+
+    #[test]
     fn test_query_by_column_name() {
         let db = Connection::open_in_memory().unwrap();
         let sql = "BEGIN;


### PR DESCRIPTION
Make possible to convert a `FromSqlError` into an `Error` (#493)