### PR TITLE
Allow specifying both `sqlcipher` and `bundled`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - cargo build
   - cargo build --features bundled
   - cargo build --features sqlcipher
+  - cargo build --features "bundled sqlcipher"
   - cargo test
   - cargo test --features backup
   - cargo test --features blob


### PR DESCRIPTION
This is useful because currently, when using `rusqlite` in a Cargo workspace with one crate that uses `sqlcipher` and another that uses `bundled`, a build error will be triggered by an unqualified `cargo
build` (as cargo will use the union of all features enabled by crates in the workspace).

Instead of panicing, this just emits a warning, before (mostly) ignoring that the `bundled` feature was specified. Note: in this configuration, we still use our bundled bindings, to avoid changing `rusqlite` to
handle this edge case (hence 'mostly').