### PR TITLE
Increase bundled SQLite variables and depth

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -52,6 +52,8 @@ mod build_bundled {
         let mut cfg = cc::Build::new();
         cfg.file("sqlite3/sqlite3.c")
             .flag("-DSQLITE_CORE")
+            .flag("-DSQLITE_MAX_VARIABLE_NUMBER=250000")
+            .flag("-DSQLITE_MAX_EXPR_DEPTH=10000")
             .flag("-DSQLITE_DEFAULT_FOREIGN_KEYS=1")
             .flag("-DSQLITE_ENABLE_API_ARMOR")
             .flag("-DSQLITE_ENABLE_COLUMN_METADATA")

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -29,6 +29,7 @@ fn main() {
 mod build_bundled {
     use cc;
     use std::path::Path;
+    use std::env;
 
     pub fn main(out_dir: &str, out_path: &Path) {
         if cfg!(feature = "sqlcipher") {
@@ -52,8 +53,6 @@ mod build_bundled {
         let mut cfg = cc::Build::new();
         cfg.file("sqlite3/sqlite3.c")
             .flag("-DSQLITE_CORE")
-            .flag("-DSQLITE_MAX_VARIABLE_NUMBER=250000")
-            .flag("-DSQLITE_MAX_EXPR_DEPTH=10000")
             .flag("-DSQLITE_DEFAULT_FOREIGN_KEYS=1")
             .flag("-DSQLITE_ENABLE_API_ARMOR")
             .flag("-DSQLITE_ENABLE_COLUMN_METADATA")
@@ -81,6 +80,13 @@ mod build_bundled {
         if cfg!(feature = "session") {
             cfg.flag("-DSQLITE_ENABLE_SESSION");
         }
+        if let Ok(limit) = env::var("SQLITE_MAX_VARIABLE_NUMBER") {
+            cfg.flag(&format!("-DSQLITE_MAX_VARIABLE_NUMBER={}", limit));
+        }
+        if let Ok(limit) = env::var("SQLITE_MAX_EXPR_DEPTH") {
+            cfg.flag(&format!("-DSQLITE_MAX_EXPR_DEPTH={}", limit));
+        }
+
         cfg.compile("libsqlite3.a");
 
         println!("cargo:lib_dir={}", out_dir);

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -80,12 +80,16 @@ mod build_bundled {
         if cfg!(feature = "session") {
             cfg.flag("-DSQLITE_ENABLE_SESSION");
         }
+
         if let Ok(limit) = env::var("SQLITE_MAX_VARIABLE_NUMBER") {
             cfg.flag(&format!("-DSQLITE_MAX_VARIABLE_NUMBER={}", limit));
         }
+        println!("cargo:rerun-if-env-changed=SQLITE_MAX_VARIABLE_NUMBER");
+
         if let Ok(limit) = env::var("SQLITE_MAX_EXPR_DEPTH") {
             cfg.flag(&format!("-DSQLITE_MAX_EXPR_DEPTH={}", limit));
         }
+        println!("cargo:rerun-if-env-changed=SQLITE_MAX_EXPR_DEPTH");
 
         cfg.compile("libsqlite3.a");
 


### PR DESCRIPTION
We've been hitting the default `MAX_VARIABLE_NUMBER` and
`MAX_EXPR_DEPTH` with quite basic tests here in Prisma. I was able to
run the tests by using the Arch Linux packaged libsqlite3, but when
turning on the bundled version I was able to get my test to crash with
this test project:

https://github.com/pimeys/sqlite_parameter_test

Now taking a look how Arch Linux builds sqlite, I was able to find two
flags fixing the issue:

https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/sqlite#n35

I think it would be safe to include them in rusqlite.