### PR TITLE
expose stmt.column_names from row objects

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -277,6 +277,11 @@ impl<'stmt> Row<'stmt> {
     pub fn get_raw<I: RowIndex>(&self, idx: I) -> ValueRef<'_> {
         self.get_raw_checked(idx).unwrap()
     }
+
+    /// Get all the column names in the result set of the prepared statement.
+    pub fn column_names(&self) -> Vec<&str> {
+        self.stmt.column_names()
+    }
 }
 
 /// A trait implemented by types that can index into columns of a row.


### PR DESCRIPTION
I have offended the borrow checker while trying to deserialize rows in case where I can't know which columns were selected and need to call `query_map()` or loop through the `MappedRow` objects. A call to column_name borrows `prep_stmt` which causes a problem when mutably borrowing `prep_stmt` for the call to `query_map()`. 

```rust
          // non-mutable borrow here
          let columns = prep_stmt.column_names();  

          //mutable borrow here
          let driver_rows = prep_stmt
              .query_map(&bindings, |driver_row| {
                  let map = columns.iter().enumerate().fold(BTreeMap::new(), |mut acc, (i, column_name)| {
                      let _ = acc.entry(SerdeValue::String(column_name.to_string())).or_insert(
                          match driver_row.get_raw(i) {
                              RusqliteValueRef::Null => SerdeValue::Unit,
                              RusqliteValueRef::Integer(int) => SerdeValue::I64(int),
                              RusqliteValueRef::Real(r) => SerdeValue::F64(r),
                              RusqliteValueRef::Text(t) => SerdeValue::String(t.to_string()),
                              RusqliteValueRef::Blob(vc) => {
                                  let s = std::string::String::from_utf8(vc.to_vec()).unwrap();
  
                                  SerdeValue::String(s)
                              }
                          }
                      );
```
I tried a few variations but couldn't find a way that I didn't end up without similar borrower checker issues. 

With this change I am able to simply get the column_names from the `Row` which I am mapping and avoid the issue altogether.

```rust
          let driver_rows = prep_stmt
              .query_map(&bindings, |driver_row| {
                  let columns = driver_row.column_names();
                  let map = columns.iter().enumerate().fold(BTreeMap::new(), |mut acc, (i, column_name)| {
                      let _ = acc.entry(SerdeValue::String(column_name.to_string())).or_insert(
                          match driver_row.get_raw(i) {
                              RusqliteValueRef::Null => SerdeValue::Unit,
                              RusqliteValueRef::Integer(int) => SerdeValue::I64(int),
                              RusqliteValueRef::Real(r) => SerdeValue::F64(r),
                              RusqliteValueRef::Text(t) => SerdeValue::String(t.to_string()),
                              RusqliteValueRef::Blob(vc) => {
                                  let s = std::string::String::from_utf8(vc.to_vec()).unwrap();
  
                                  SerdeValue::String(s)
                              }
                          }
  
                      );
  
                      acc
                  });
  
                  Ok(map)
              })
          .unwrap();
```

Please let me know if you think this is a reasonable change and if you would like any additional testing or documentation added and I will get those included.