### PR TITLE
add ability to open sqlite connection with specified vfs

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -57,7 +57,7 @@ impl InnerConnection {
         }
     }
 
-    pub fn open_with_flags(c_path: &CString, flags: OpenFlags) -> Result<InnerConnection> {
+    pub fn open_with_flags(c_path: &CString, flags: OpenFlags, vfs: Option(&CString)) -> Result<InnerConnection> {
         #[cfg(not(feature = "bundled"))]
         ensure_valid_sqlite_version();
         ensure_safe_sqlite_threading_mode()?;
@@ -77,9 +77,14 @@ impl InnerConnection {
             ));
         }
 
+        z_vfs = match(vfs) {
+            Some(c_vfs) => c_vfs.as_ptr(),
+            None => ptr::null()
+        }
+
         unsafe {
             let mut db: *mut ffi::sqlite3 = mem::uninitialized();
-            let r = ffi::sqlite3_open_v2(c_path.as_ptr(), &mut db, flags.bits(), ptr::null());
+            let r = ffi::sqlite3_open_v2(c_path.as_ptr(), &mut db, flags.bits(), z_vfs);
             if r != ffi::SQLITE_OK {
                 let e = if db.is_null() {
                     error_from_sqlite_code(r, None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ impl Connection {
     /// string or if the underlying SQLite open call fails.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Connection> {
         let flags = OpenFlags::default();
-        Connection::open_with_flags(path, flags)
+        Connection::open_with_flags(path, flags, None)
     }
 
     /// Open a new connection to an in-memory SQLite database.
@@ -366,7 +366,26 @@ impl Connection {
     /// string or if the underlying SQLite open call fails.
     pub fn open_with_flags<P: AsRef<Path>>(path: P, flags: OpenFlags) -> Result<Connection> {
         let c_path = path_to_cstring(path.as_ref())?;
-        InnerConnection::open_with_flags(&c_path, flags).map(|db| Connection {
+        InnerConnection::open_with_flags(&c_path, flags, None).map(|db| Connection {
+            db: RefCell::new(db),
+            cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            path: Some(path.as_ref().to_path_buf()),
+        })
+    }
+
+    /// Open a new connection to a SQLite database using the specific flags and vfs name.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
+    /// flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if either `path` or `vfs` cannot be converted to a C-compatible
+    /// string or if the underlying SQLite open call fails. 
+    pub fn open_with_flags_and_vfs<P: AsRef<Path>>(path: P, flags: OpenFlags, vfs: &str) -> Result<Connection> {
+        let c_path = path_to_cstring(path.as_ref())?;
+        let c_vfs = str_to_cstring(vfs)?;
+        InnerConnection::open_with_flags(&c_path, flags, Some(c_vfs)).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
             path: Some(path.as_ref().to_path_buf()),
@@ -383,7 +402,26 @@ impl Connection {
     /// Will return `Err` if the underlying SQLite open call fails.
     pub fn open_in_memory_with_flags(flags: OpenFlags) -> Result<Connection> {
         let c_memory = str_to_cstring(":memory:")?;
-        InnerConnection::open_with_flags(&c_memory, flags).map(|db| Connection {
+        InnerConnection::open_with_flags(&c_memory, flags, None).map(|db| Connection {
+            db: RefCell::new(db),
+            cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            path: None,
+        })
+    }
+
+    /// Open a new connection to an in-memory SQLite database using the specific flags and vfs name.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a description of valid
+    /// flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if vfs` cannot be converted to a C-compatible
+    /// string or if the underlying SQLite open call fails.
+    pub fn open_in_memory_with_flags_and_vfs(flags: OpenFlags, vfs: &str) -> Result<Connection> {
+        let c_memory = str_to_cstring(":memory:")?;
+        let c_vfs = str_to_cstring(vfs)?;
+        InnerConnection::open_with_flags(&c_memory, flags, Some(c_vfs)).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
             path: None,


### PR DESCRIPTION
adds two new functions to create a connection:
`open_with_flags_and_vfs()` and `open_in_memory_with_flags_and_vfs()` that allow a speciifc sqlite VFS (https://sqlite.org/vfs.html) to be used. 

The actual pass-through of the vfs is done within InnerConnection. I assume that is intended to be a private interface so I opted to change the signature of the InnerConnection `open_with_flags()` function to accept a third `Option` argument for the vfs. If that is not acceptable it could easily be refactored into a separate function. 