### PR TITLE
Include the name of the column in InvalidColumnType errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
     /// Error when the value of a particular column is requested, but the type
     /// of the result in that column cannot be converted to the requested
     /// Rust type.
-    InvalidColumnType(usize, Type),
+    InvalidColumnType(usize, String, Type),
 
     /// Error when a query that was expected to insert one row did not insert
     /// any or insert many.
@@ -117,8 +117,8 @@ impl PartialEq for Error {
             (Error::QueryReturnedNoRows, Error::QueryReturnedNoRows) => true,
             (Error::InvalidColumnIndex(i1), Error::InvalidColumnIndex(i2)) => i1 == i2,
             (Error::InvalidColumnName(n1), Error::InvalidColumnName(n2)) => n1 == n2,
-            (Error::InvalidColumnType(i1, t1), Error::InvalidColumnType(i2, t2)) => {
-                i1 == i2 && t1 == t2
+            (Error::InvalidColumnType(i1, n1, t1), Error::InvalidColumnType(i2, n2, t2)) => {
+                i1 == i2 && t1 == t2 && n1 == n2
             }
             (Error::StatementChangedRows(n1), Error::StatementChangedRows(n2)) => n1 == n2,
             #[cfg(feature = "functions")]
@@ -182,8 +182,8 @@ impl fmt::Display for Error {
             Error::QueryReturnedNoRows => write!(f, "Query returned no rows"),
             Error::InvalidColumnIndex(i) => write!(f, "Invalid column index: {}", i),
             Error::InvalidColumnName(ref name) => write!(f, "Invalid column name: {}", name),
-            Error::InvalidColumnType(i, ref t) => {
-                write!(f, "Invalid column type {} at index: {}", t, i)
+            Error::InvalidColumnType(i, ref name, ref t) => {
+                write!(f, "Invalid column type {} at index: {}, name: {}", t, i, name)
             }
             Error::StatementChangedRows(i) => write!(f, "Query changed {} rows", i),
 
@@ -229,7 +229,7 @@ impl error::Error for Error {
             Error::QueryReturnedNoRows => "query returned no rows",
             Error::InvalidColumnIndex(_) => "invalid column index",
             Error::InvalidColumnName(_) => "invalid column name",
-            Error::InvalidColumnType(_, _) => "invalid column type",
+            Error::InvalidColumnType(_, _, _) => "invalid column type",
             Error::StatementChangedRows(_) => "query inserted zero or more than one row",
 
             #[cfg(feature = "functions")]
@@ -262,7 +262,7 @@ impl error::Error for Error {
             | Error::QueryReturnedNoRows
             | Error::InvalidColumnIndex(_)
             | Error::InvalidColumnName(_)
-            | Error::InvalidColumnType(_, _)
+            | Error::InvalidColumnType(_, _, _)
             | Error::InvalidPath(_)
             | Error::StatementChangedRows(_)
             | Error::InvalidQuery => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1476,7 +1476,7 @@ mod test {
                 .collect();
 
             match bad_type.unwrap_err() {
-                Error::InvalidColumnType(_, _) => (),
+                Error::InvalidColumnType(_, _, _) => (),
                 err => panic!("Unexpected error {}", err),
             }
 
@@ -1531,7 +1531,7 @@ mod test {
                 .collect();
 
             match bad_type.unwrap_err() {
-                CustomError::Sqlite(Error::InvalidColumnType(_, _)) => (),
+                CustomError::Sqlite(Error::InvalidColumnType(_, _, _)) => (),
                 err => panic!("Unexpected error {}", err),
             }
 
@@ -1588,7 +1588,7 @@ mod test {
             });
 
             match bad_type.unwrap_err() {
-                CustomError::Sqlite(Error::InvalidColumnType(_, _)) => (),
+                CustomError::Sqlite(Error::InvalidColumnType(_, _, _)) => (),
                 err => panic!("Unexpected error {}", err),
             }
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -223,15 +223,15 @@ impl<'stmt> Row<'stmt> {
         let idx = idx.idx(self.stmt)?;
         let value = self.stmt.value_ref(idx);
         FromSql::column_result(value).map_err(|err| match err {
-            FromSqlError::InvalidType => Error::InvalidColumnType(idx, value.data_type()),
+            FromSqlError::InvalidType => Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type()),
             FromSqlError::OutOfRange(i) => Error::IntegralValueOutOfRange(idx, i),
             FromSqlError::Other(err) => {
                 Error::FromSqlConversionFailure(idx as usize, value.data_type(), err)
             }
             #[cfg(feature = "i128_blob")]
-            FromSqlError::InvalidI128Size(_) => Error::InvalidColumnType(idx, value.data_type()),
+            FromSqlError::InvalidI128Size(_) => Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type()),
             #[cfg(feature = "uuid")]
-            FromSqlError::InvalidUuidSize(_) => Error::InvalidColumnType(idx, value.data_type()),
+            FromSqlError::InvalidUuidSize(_) => Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type()),
         })
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -229,7 +229,7 @@ mod test {
     fn test_mismatched_types() {
         fn is_invalid_column_type(err: Error) -> bool {
             match err {
-                Error::InvalidColumnType(_, _) => true,
+                Error::InvalidColumnType(_, _, _) => true,
                 _ => false,
             }
         }

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -472,7 +472,7 @@ impl Values<'_> {
             }
             FromSqlError::OutOfRange(i) => Error::IntegralValueOutOfRange(idx, i),
             #[cfg(feature = "i128_blob")]
-            FromSqlError::InvalidI128Size(_) => Error::InvalidColumnType(idx, value.data_type()),
+            FromSqlError::InvalidI128Size(_) => Error::InvalidColumnType(idx, idx.to_string(), value.data_type()),
             #[cfg(feature = "uuid")]
             FromSqlError::InvalidUuidSize(_) => {
                 Error::FromSqlConversionFailure(idx, value.data_type(), Box::new(err))


### PR DESCRIPTION
We're hitting this in the wild on firefox-ios and knowing that some query has a Null for column 3 is... not particularly actionable. The column name would at least give us a starting place.

I've also made it perform bounds checking on the index in column_name, even though it just panics on out of bounds for now, and refactored that code a little.

It would be nice to get this in a release after it lands, but if that ends up not being possible timing-wise I can just point at my fork.