### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bundled = ["libsqlite3-sys/bundled"]
 buildtime_bindgen = ["libsqlite3-sys/buildtime_bindgen"]
 limits = []
 hooks = []
-i128_blob = ["byteorder"]
+i128_blob = []
 sqlcipher = ["libsqlite3-sys/sqlcipher"]
 unlock_notify = ["libsqlite3-sys/unlock_notify"]
 # xSavepoint, xRelease and xRollbackTo: 3.7.7 (2011-06-23)
@@ -64,7 +64,6 @@ serde_json = { version = "1.0", optional = true }
 csv = { version = "1.0", optional = true }
 url = { version = "2.0", optional = true }
 lazy_static = { version = "1.0", optional = true }
-byteorder = { version = "1.2", features = ["i128"], optional = true }
 fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
 memchr = "2.2.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use crate::types::Type;
 use crate::types::FromSqlError;
+use crate::types::Type;
 use crate::{errmsg_to_string, ffi};
 use std::error;
 use std::fmt;
@@ -190,20 +190,24 @@ impl fmt::Display for Error {
                 f,
                 "SQLite was compiled or configured for single-threaded use only"
             ),
-            Error::FromSqlConversionFailure(i, ref t, ref err) => if i != UNKNOWN_COLUMN {
-                write!(
-                    f,
-                    "Conversion error from type {} at index: {}, {}",
-                    t, i, err
-                )
-            } else {
-                err.fmt(f)
-            },
-            Error::IntegralValueOutOfRange(col, val) => if col != UNKNOWN_COLUMN {
-                write!(f, "Integer {} out of range at index {}", val, col)
-            } else {
-                write!(f, "Integer {} out of range", val)
-            },
+            Error::FromSqlConversionFailure(i, ref t, ref err) => {
+                if i != UNKNOWN_COLUMN {
+                    write!(
+                        f,
+                        "Conversion error from type {} at index: {}, {}",
+                        t, i, err
+                    )
+                } else {
+                    err.fmt(f)
+                }
+            }
+            Error::IntegralValueOutOfRange(col, val) => {
+                if col != UNKNOWN_COLUMN {
+                    write!(f, "Integer {} out of range at index {}", val, col)
+                } else {
+                    write!(f, "Integer {} out of range", val)
+                }
+            }
             Error::Utf8Error(ref err) => err.fmt(f),
             Error::NulError(ref err) => err.fmt(f),
             Error::InvalidParameterName(ref name) => write!(f, "Invalid parameter name: {}", name),

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -175,13 +175,14 @@ impl FromSql for Vec<u8> {
 #[cfg(feature = "i128_blob")]
 impl FromSql for i128 {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        use byteorder::{BigEndian, ByteOrder};
-
-        value.as_blob().and_then(|bytes| {
-            if bytes.len() == 16 {
-                Ok(BigEndian::read_i128(bytes) ^ (1i128 << 127))
+        value.as_blob().and_then(|b| {
+            if b.len() == 16 {
+                Ok(i128::from_be_bytes([
+                    b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11],
+                    b[12], b[13], b[14], b[15],
+                ]) ^ (1i128 << 127))
             } else {
-                Err(FromSqlError::InvalidI128Size(bytes.len()))
+                Err(FromSqlError::InvalidI128Size(b.len()))
             }
         })
     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -39,12 +39,9 @@ impl From<isize> for Value {
 #[cfg(feature = "i128_blob")]
 impl From<i128> for Value {
     fn from(i: i128) -> Value {
-        use byteorder::{BigEndian, ByteOrder};
-        let mut buf = vec![0u8; 16];
         // We store these biased (e.g. with the most significant bit flipped)
         // so that comparisons with negative numbers work properly.
-        BigEndian::write_i128(&mut buf, i ^ (1i128 << 127));
-        Value::Blob(buf)
+        Value::Blob((i ^ (1i128 << 127)).to_be_bytes().to_vec())
     }
 }
 


### PR DESCRIPTION
This removes the `byteorder`-dependency, which was used for the `i128_blob`-feature and is not strictly required since Rust 1.32, when `i128::(from|to)_be_bytes()` was stabilized. I think dropping a dependency is worth the change.

Notice that I left the `i128_blob`-feature in place, although it's not actually useful anymore besides disabling a tiny amount of code to be compiled; keeping it in place preserves semver compatibility, though. The feature could be removed later on.