### PR TITLE
Make `column_name()` public and forward all column methods in Row and Rows

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -9,14 +9,14 @@ pub struct Column<'stmt> {
     decl_type: Option<&'stmt str>,
 }
 
-impl Column<'_> {
+impl<'stmt> Column<'stmt> {
     /// Returns the name of the column.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'stmt str {
         self.name
     }
 
     /// Returns the type of the column (`None` for expression).
-    pub fn decl_type(&self) -> Option<&str> {
+    pub fn decl_type(&self) -> Option<&'stmt str> {
         self.decl_type
     }
 }
@@ -68,7 +68,7 @@ impl Statement<'_> {
     }
 
     /// Returns a slice describing the columns of the result of the query.
-    pub fn columns<'stmt>(&'stmt self) -> Vec<Column<'stmt>> {
+    pub fn columns(&self) -> Vec<Column> {
         let n = self.column_count();
         let mut cols = Vec::with_capacity(n as usize);
         for i in 0..n {
@@ -83,7 +83,7 @@ impl Statement<'_> {
 
 impl<'stmt> Rows<'stmt> {
     /// Get all the column names.
-    pub fn column_names(&self) -> Option<Vec<&str>> {
+    pub fn column_names(&self) -> Option<Vec<&'stmt str>> {
         self.stmt.map(Statement::column_names)
     }
 
@@ -93,7 +93,7 @@ impl<'stmt> Rows<'stmt> {
     }
 
     /// Return the name of the column.
-    pub fn column_name(&self, col: usize) -> Option<&str> {
+    pub fn column_name(&self, col: usize) -> Option<&'stmt str> {
         self.stmt.and_then(|x| x.column_name(col))
     }
 
@@ -110,7 +110,7 @@ impl<'stmt> Rows<'stmt> {
 
 impl<'stmt> Row<'stmt> {
     /// Get all the column names of the Row.
-    pub fn column_names(&self) -> Vec<&str> {
+    pub fn column_names(&self) -> Vec<&'stmt str> {
         self.stmt.column_names()
     }
 
@@ -120,7 +120,7 @@ impl<'stmt> Row<'stmt> {
     }
 
     /// Return the name of the column.
-    pub fn column_name(&self, col: usize) -> Option<&str> {
+    pub fn column_name(&self, col: usize) -> Option<&'stmt str> {
         self.stmt.column_name(col)
     }
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -75,7 +75,7 @@ impl Statement<'_> {
         for i in 0..n {
             let name = self.column_name(i);
             let slice = self.stmt.column_decltype(i);
-            let decl_type = slice.map(|s| str::from_utf8(s.to_bytes()).unwrap());
+            let decl_type = slice.map(|s| str::from_utf8(s.to_bytes()).expect("Invalid UTF-8 sequence in column declaration"));
             cols.push(Column { name, decl_type });
         }
         cols

--- a/src/column.rs
+++ b/src/column.rs
@@ -92,6 +92,16 @@ impl<'stmt> Rows<'stmt> {
         self.stmt.map(Statement::column_count)
     }
 
+    /// Return the name of the column.
+    pub fn column_name(&self, col: usize) -> Option<&str> {
+        self.stmt.and_then(|x| x.column_name(col))
+    }
+
+    /// Return the index of the column.
+    pub fn column_index(&self, name: &str) -> Option<Result<usize>> {
+        self.stmt.map(|x| x.column_index(name))
+    }
+
     /// Returns a slice describing the columns of the Rows.
     pub fn columns(&self) -> Option<Vec<Column<'stmt>>> {
         self.stmt.map(Statement::columns)
@@ -99,11 +109,25 @@ impl<'stmt> Rows<'stmt> {
 }
 
 impl<'stmt> Row<'stmt> {
+    /// Get all the column names of the Row.
+    pub fn column_names(&self) -> Vec<&str> {
+        self.stmt.column_names()
+    }
+
     /// Return the number of columns in the current row.
     pub fn column_count(&self) -> usize {
         self.stmt.column_count()
     }
 
+    /// Return the name of the column.
+    pub fn column_name(&self, col: usize) -> Option<&str> {
+        self.stmt.column_name(col)
+    }
+
+    /// Return the index of the column.
+    pub fn column_index(&self, name: &str) -> Result<usize> {
+        self.stmt.column_index(name)
+    }
     /// Returns a slice describing the columns of the Row.
     pub fn columns(&self) -> Vec<Column<'stmt>> {
         self.stmt.columns()

--- a/src/row.rs
+++ b/src/row.rs
@@ -224,7 +224,7 @@ impl<'stmt> Row<'stmt> {
         let value = self.stmt.value_ref(idx);
         FromSql::column_result(value).map_err(|err| match err {
             FromSqlError::InvalidType => {
-                Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type())
+                Error::InvalidColumnType(idx, self.stmt.column_name(idx).unwrap().into(), value.data_type())
             }
             FromSqlError::OutOfRange(i) => Error::IntegralValueOutOfRange(idx, i),
             FromSqlError::Other(err) => {
@@ -232,11 +232,11 @@ impl<'stmt> Row<'stmt> {
             }
             #[cfg(feature = "i128_blob")]
             FromSqlError::InvalidI128Size(_) => {
-                Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type())
+                Error::InvalidColumnType(idx, self.stmt.column_name(idx).unwrap().into(), value.data_type())
             }
             #[cfg(feature = "uuid")]
             FromSqlError::InvalidUuidSize(_) => {
-                Error::InvalidColumnType(idx, self.stmt.column_name(idx).into(), value.data_type())
+                Error::InvalidColumnType(idx, self.stmt.column_name(idx).unwrap().into(), value.data_type())
             }
         })
     }


### PR DESCRIPTION
Hi,

Having `column_name()` accessible really helps with avoiding allocations. And there was an obvious mismatch between column methods in Statement, Row and Rows.