### PR TITLE
Check SQL query passed to `execute`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - cargo build --features sqlcipher
   - cargo build --features "bundled sqlcipher"
   - cargo test
-  - cargo test --features "backup blob"
+  - cargo test --features "backup blob extra_check"
   - cargo test --features "collation functions"
   - cargo test --features "hooks limits"
   - cargo test --features load_extension

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,13 @@ csvtab = ["csv", "vtab"]
 # pointer passing interfaces: 3.20.0
 array = ["vtab"]
 # session extension: 3.13.0
-session = ["libsqlite3-sys/session", "hooks"]
+#session = ["libsqlite3-sys/session", "hooks"]
 # window functions: 3.25.0
 window = ["functions"]
 # 3.9.0
 series = ["vtab"]
-
+# check for invalid query.
+extra_check = []
 
 [dependencies]
 time = "0.1.0"

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -125,7 +125,9 @@ impl InnerConnection {
                     str::from_utf8_unchecked(c_slice)
                 };
                 callback(&conn, collation_name)
-            }).is_err() {
+            })
+            .is_err()
+            {
                 return; // FIXME How ?
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,8 @@ mod test {
             )
             .expect("create temp db");
 
-        let mut db1 = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE).unwrap();
+        let mut db1 =
+            Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE).unwrap();
         let mut db2 = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
 
         db1.busy_timeout(Duration::from_millis(0)).unwrap();


### PR DESCRIPTION
When `extra_check` feature is activated:
Fail when query has a column count > 0
Or when query is readonly.

Should fix #565