### PR TITLE
Ignore `mutex_atomic` clippy lint

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -37,6 +37,7 @@ pub struct InnerConnection {
 
 impl InnerConnection {
     #[cfg(not(feature = "hooks"))]
+    #[allow(clippy::mutex_atomic)]
     pub fn new(db: *mut ffi::sqlite3, owned: bool) -> InnerConnection {
         InnerConnection {
             db,
@@ -46,6 +47,7 @@ impl InnerConnection {
     }
 
     #[cfg(feature = "hooks")]
+    #[allow(clippy::mutex_atomic)]
     pub fn new(db: *mut ffi::sqlite3, owned: bool) -> InnerConnection {
         InnerConnection {
             db,
@@ -123,6 +125,7 @@ impl InnerConnection {
         }
     }
 
+    #[allow(clippy::mutex_atomic)]
     pub fn close(&mut self) -> Result<()> {
         if self.db.is_null() {
             return Ok(());

--- a/src/unlock_notify.rs
+++ b/src/unlock_notify.rs
@@ -17,6 +17,7 @@ struct UnlockNotification {
 }
 
 #[cfg(feature = "unlock_notify")]
+#[allow(clippy::mutex_atomic)]
 impl UnlockNotification {
     fn new() -> UnlockNotification {
         UnlockNotification {


### PR DESCRIPTION
> This lint cannot detect if the mutex is actually used for waiting
before a critical section.