### PR TITLE
Replace deprecated tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ memchr = "2.2.0"
 uuid = { version = "0.8", optional = true }
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3.1.0"
 lazy_static = "1.0"
 regex = "1.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/busy.rs
+++ b/src/busy.rs
@@ -79,13 +79,13 @@ mod test {
     use std::sync::mpsc::sync_channel;
     use std::thread;
     use std::time::Duration;
-    use tempdir::TempDir;
+    use tempfile;
 
     use crate::{Connection, Error, ErrorCode, Result, TransactionBehavior, NO_PARAMS};
 
     #[test]
     fn test_default_busy() {
-        let temp_dir = TempDir::new("test_default_busy").unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("test.db3");
 
         let mut db1 = Connection::open(&path).unwrap();
@@ -106,7 +106,7 @@ mod test {
     #[test]
     #[ignore] // FIXME: unstable
     fn test_busy_timeout() {
-        let temp_dir = TempDir::new("test_busy_timeout").unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("test.db3");
 
         let db2 = Connection::open(&path).unwrap();
@@ -145,7 +145,7 @@ mod test {
             true
         }
 
-        let temp_dir = TempDir::new("test_busy_handler").unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("test.db3");
 
         let db2 = Connection::open(&path).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,7 +869,7 @@ mod test {
     use fallible_iterator::FallibleIterator;
     use std::error::Error as StdError;
     use std::fmt;
-    use tempdir::TempDir;
+    use tempfile;
 
     // this function is never called, but is still type checked; in
     // particular, calls with specific instantiations will require
@@ -892,7 +892,7 @@ mod test {
     #[test]
     fn test_concurrent_transactions_busy_commit() {
         use std::time::Duration;
-        let tmp = TempDir::new("locked").unwrap();
+        let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("transactions.db3");
 
         Connection::open(&path)
@@ -938,7 +938,7 @@ mod test {
 
     #[test]
     fn test_persistence() {
-        let temp_dir = TempDir::new("test_open_file").unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("test.db3");
 
         {


### PR DESCRIPTION
`tempdir` has been deprecated for a while and `tempfile` has a new version out that uses a new version of `rand` that doesn't depend on `winapi` anymore.

So this also removes one dependency on the `winapi` crate.  The current version of the `time` crate also depends on `winapi,` but work is being done to replace that version with 0.2 to remove the `winapi` dependency.