### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# see https://editorconfig.org for more options, and setup instructions for yours editor
+
+[*.rs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This avoids annoying wrong indentation when people use tabs in their editors (like they are supposed to :speak_no_evil:).