### PR TITLE
Allow crates with a direct dep on libsqlite3-sys to know if `sqlcipher` has been enabled

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -206,6 +206,13 @@ mod build_linked {
         if cfg!(all(feature = "vcpkg", target_env = "msvc")) {
             println!("cargo:rerun-if-env-changed=VCPKGRS_DYNAMIC");
         }
+
+        // dependents can access `DEP_SQLITE3_LINK_TARGET` (`sqlite3` being the
+        // `links=` value in our Cargo.toml) to get this value. This might be
+        // useful if you need to ensure whatever crypto library sqlcipher relies
+        // on is available, for example.
+        println!("cargo:link-target={}", link_lib);
+
         // Allow users to specify where to find SQLite.
         if let Ok(dir) = env::var(format!("{}_LIB_DIR", env_prefix())) {
             // Try to use pkg-config to determine link commands


### PR DESCRIPTION
If something else (another crate in your workspace when building with --all, for example) turns sqlcipher on, but isn't part of your build, you'll have issues, as the crypto lib might not get linked.

This way, a dependent build.rs can inspect the env var cargo sets and link the crypto lib if necessary. (... This is a pretty annoying situation to be in, but it doesn't complicate the build.rs really, and I don't really think there's really many other ways if you're in that situation).

In the future it would probably be nice to better support sqlcipher's configuration, but there's only so much env vars + cargo features can manage...