### PR TITLE
Add FromSql for Box<str>, Rc<str> and Arc<str>

### DIFF
--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -166,6 +166,24 @@ impl FromSql for String {
     }
 }
 
+impl FromSql for Box<str> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str().map(Into::into)
+    }
+}
+
+impl FromSql for std::rc::Rc<str> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str().map(Into::into)
+    }
+}
+
+impl FromSql for std::sync::Arc<str> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str().map(Into::into)
+    }
+}
+
 impl FromSql for Vec<u8> {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         value.as_blob().map(|b| b.to_vec())


### PR DESCRIPTION
I often work with ref-counted strings, and it it's nice to be able to extract these directly. Note that for Rc/Arc, this avoids a copy that would be present if we went through String.

Didn't bother for the blob equivalents (`Box<[u8]>`, `Rc<[u8]>`, `Arc<[u8]>`) since I'm not sure it matters.