### PR TITLE
Separate the `modern_sqlite` and `bundled` features. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ collation = []
 functions = ["libsqlite3-sys/min_sqlite_version_3_7_7"]
 # sqlite3_log: 3.6.23 (2010-03-09)
 trace = ["libsqlite3-sys/min_sqlite_version_3_6_23"]
-bundled = ["libsqlite3-sys/bundled"]
+bundled = ["libsqlite3-sys/bundled", "modern_sqlite"]
 buildtime_bindgen = ["libsqlite3-sys/buildtime_bindgen"]
 limits = []
 hooks = []
@@ -55,6 +55,7 @@ window = ["functions"]
 series = ["vtab"]
 # check for invalid query.
 extra_check = []
+modern_sqlite = ["libsqlite3-sys/bundled_bindings"]
 
 [dependencies]
 time = "0.1.0"
@@ -93,7 +94,7 @@ name = "deny_single_threaded_sqlite_config"
 name = "vtab"
 
 [package.metadata.docs.rs]
-features = [ "backup", "blob", "chrono", "collation", "functions", "limits", "load_extension", "serde_json", "trace", "url", "vtab", "window" ]
+features = [ "backup", "blob", "chrono", "collation", "functions", "limits", "load_extension", "serde_json", "trace", "url", "vtab", "window", "modern_sqlite" ]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ bundled version of SQLite. If you need other specific pregenerated binding
 versions, please file an issue. If you want to run `bindgen` at buildtime to
 produce your own bindings, use the `buildtime_bindgen` Cargo feature.
 
+If you enable the `modern_sqlite` feature, we'll use the bindings we would have
+included with the bundled build. You generally should have `buildtime_bindgen`
+enabled if you turn this on, as otherwise you'll need to keep the version of
+SQLite you link with in sync with what rusqlite would have bundled, (usually the
+most recent release of sqlite). Failing to do this will cause a runtime error.
+
 ## Author
 
 John Gallagher, johnkgallagher@gmail.com

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -13,14 +13,17 @@ categories = ["external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]
-bundled = ["cc"]
-bundled-windows = ["cc"]
+bundled = ["cc", "bundled_bindings"]
+bundled-windows = ["cc", "bundled_bindings"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
 sqlcipher = []
 min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_6_23 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_7_7 = ["pkg-config", "vcpkg"]
 min_sqlite_version_3_7_16 = ["pkg-config", "vcpkg"]
+# Bundle only the bindings file. Note that this does nothing if
+# `buildtime_bindgen` is enabled.
+bundled_bindings = []
 # sqlite3_unlock_notify >= 3.6.12
 unlock_notify = []
 # 3.13.0

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -166,18 +166,17 @@ mod build_linked {
     pub fn main(_out_dir: &str, out_path: &Path) {
         let header = find_sqlite();
         if cfg!(any(
+            feature = "bundled_bindings",
             feature = "bundled",
             all(windows, feature = "bundled-windows")
         )) && !cfg!(feature = "buildtime_bindgen")
         {
-            // We can only get here if `bundled` and `sqlcipher` were both
-            // specified (and `builtime_bindgen` was not). In order to keep
-            // `rusqlite` relatively clean we hide the fact that `bundled` can
-            // be ignored in some cases, and just use the bundled bindings, even
-            // though the library we found might not match their version.
-            // Ideally we'd perform a version check here, but doing so is rather
-            // tricky, since we might not have access to executables (and
-            // moreover, we might be cross compiling).
+            // Generally means the `bundled_bindings` feature is enabled
+            // (there's also an edge case where we get here involving
+            // sqlcipher). In either case most users are better off with turning
+            // on buildtime_bindgen instead, but this is still supported as we
+            // have runtime version checks and there are good reasons to not
+            // want to run bindgen.
             std::fs::copy("sqlite3/bindgen_bundled_version.rs", out_path)
                 .expect("Could not copy bindings to output directory");
         } else {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -81,11 +81,11 @@ unsafe fn report_error(ctx: *mut sqlite3_context, err: &Error) {
     // an explicit feature check for that, and this doesn't really warrant one.
     // We'll use the extended code if we're on the bundled version (since it's
     // at least 3.17.0) and the normal constraint error code if not.
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     fn constraint_error_code() -> i32 {
         ffi::SQLITE_CONSTRAINT_FUNCTION
     }
-    #[cfg(not(feature = "bundled"))]
+    #[cfg(not(feature = "modern_sqlite"))]
     fn constraint_error_code() -> i32 {
         ffi::SQLITE_CONSTRAINT
     }

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -281,7 +281,7 @@ impl InnerConnection {
         unsafe { ffi::sqlite3_get_autocommit(self.db()) != 0 }
     }
 
-    #[cfg(feature = "bundled")] // 3.8.6
+    #[cfg(feature = "modern_sqlite")] // 3.8.6
     pub fn is_busy(&self) -> bool {
         let db = self.db();
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ pub enum DatabaseName<'a> {
     feature = "backup",
     feature = "blob",
     feature = "session",
-    feature = "bundled"
+    feature = "modern_sqlite"
 ))]
 impl DatabaseName<'_> {
     fn to_cstring(&self) -> Result<CString> {
@@ -750,7 +750,7 @@ impl Connection {
     }
 
     /// Determine if all associated prepared statements have been reset.
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")] // 3.8.6
     pub fn is_busy(&self) -> bool {
         self.db.borrow().is_busy()
     }
@@ -847,7 +847,7 @@ impl InterruptHandle {
     }
 }
 
-#[cfg(feature = "bundled")] // 3.7.10
+#[cfg(feature = "modern_sqlite")] // 3.7.10
 unsafe fn db_filename(db: *mut ffi::sqlite3) -> Option<PathBuf> {
     let db_name = DatabaseName::Main.to_cstring().unwrap();
     let db_filename = ffi::sqlite3_db_filename(db, db_name.as_ptr());
@@ -857,7 +857,7 @@ unsafe fn db_filename(db: *mut ffi::sqlite3) -> Option<PathBuf> {
         CStr::from_ptr(db_filename).to_str().ok().map(PathBuf::from)
     }
 }
-#[cfg(not(feature = "bundled"))]
+#[cfg(not(feature = "modern_sqlite"))]
 unsafe fn db_filename(_: *mut ffi::sqlite3) -> Option<PathBuf> {
     None
 }
@@ -1302,7 +1302,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     fn test_is_busy() {
         let db = checked_memory_handle();
         assert!(!db.is_busy());
@@ -1331,11 +1331,11 @@ mod test {
     fn test_notnull_constraint_error() {
         // extended error codes for constraints were added in SQLite 3.7.16; if we're
         // running on our bundled version, we know the extended error code exists.
-        #[cfg(feature = "bundled")]
+        #[cfg(feature = "modern_sqlite")]
         fn check_extended_code(extended_code: c_int) {
             assert_eq!(extended_code, ffi::SQLITE_CONSTRAINT_NOTNULL);
         }
-        #[cfg(not(feature = "bundled"))]
+        #[cfg(not(feature = "modern_sqlite"))]
         fn check_extended_code(_extended_code: c_int) {}
 
         let db = checked_memory_handle();

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -326,7 +326,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     fn pragma_func_query_value() {
         use crate::NO_PARAMS;
 
@@ -379,7 +379,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     fn pragma_func() {
         let db = Connection::open_in_memory().unwrap();
         let mut table_info = db.prepare("SELECT * FROM pragma_table_info(?)").unwrap();

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -117,13 +117,13 @@ impl RawStatement {
         r
     }
 
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")] // 3.7.4
     pub fn readonly(&self) -> bool {
         unsafe { ffi::sqlite3_stmt_readonly(self.0) != 0 }
     }
 
     /// `CStr` must be freed
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")] // 3.14.0
     pub unsafe fn expanded_sql(&self) -> Option<&CStr> {
         let ptr = ffi::sqlite3_expanded_sql(self.0);
         if ptr.is_null() {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -533,13 +533,13 @@ impl Statement<'_> {
         self.conn.decode_result(stmt.finalize())
     }
 
-    #[cfg(not(feature = "bundled"))]
+    #[cfg(not(feature = "modern_sqlite"))]
     #[inline]
     fn check_readonly(&self) -> Result<()> {
         Ok(())
     }
 
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     #[inline]
     fn check_readonly(&self) -> Result<()> {
         /*if !self.stmt.readonly() { does not work for PRAGMA
@@ -548,7 +548,7 @@ impl Statement<'_> {
         Ok(())
     }
 
-    #[cfg(all(feature = "bundled", feature = "extra_check"))]
+    #[cfg(all(feature = "modern_sqlite", feature = "extra_check"))]
     #[inline]
     fn check_update(&self) -> Result<()> {
         if self.column_count() > 0 || self.stmt.readonly() {
@@ -557,7 +557,7 @@ impl Statement<'_> {
         Ok(())
     }
 
-    #[cfg(all(not(feature = "bundled"), feature = "extra_check"))]
+    #[cfg(all(not(feature = "modern_sqlite"), feature = "extra_check"))]
     #[inline]
     fn check_update(&self) -> Result<()> {
         if self.column_count() > 0 {
@@ -574,7 +574,7 @@ impl Statement<'_> {
 
     /// Returns a string containing the SQL text of prepared statement with
     /// bound parameters expanded.
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     pub fn expanded_sql(&self) -> Option<String> {
         unsafe {
             match self.stmt.expanded_sql() {
@@ -1019,7 +1019,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "bundled")]
+    #[cfg(feature = "modern_sqlite")]
     fn test_expanded_sql() {
         let db = Connection::open_in_memory().unwrap();
         let stmt = db.prepare("SELECT ?").unwrap();


### PR DESCRIPTION
Fixes #612.

I also got rid of the vtab_v3 feature since AFAICT it's unnecessary if we change the code in the way I did. The old way could cause problems under buildtime_bindgen, as our definition of sqlite3_module might be from >3.26.

BTW what are the version checks protecting against? My understanding is that SQLite's ABI is pretty stable, so it should always be legal to use a newer header to call older code, so long as you only call functions that are present (if you call functions which aren't present, you get a linker error). E.g. it's not like sqlite changes the signatures of existing functions (hence all the `blah_v2`s that exist). Did it do so in older versions?

As it is, this *is* enough for my needs for now, I think, but it's a bit of a footgun to turn on (without also enabling buildtime_bindgen). At least, that's unless you're also going to disable the version detection, because of how aggressive said version detection is.

That said, it's possible I'm not thinking of a case where there's a safety issue.