### PR TITLE
make RawStatement public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::cache::StatementCache;
 use crate::inner_connection::{InnerConnection, BYPASS_SQLITE_INIT};
-use crate::raw_statement::RawStatement;
+pub use crate::raw_statement::RawStatement;
 use crate::types::ValueRef;
 
 pub use crate::cache::CachedStatement;


### PR DESCRIPTION
Make the RawStatement struct public to assist vtable implementations in working with underlying rusqlite statements.