### PR TITLE
make bind_parameters() on Statement public

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -424,7 +424,7 @@ impl Statement<'_> {
         Ok(self.stmt.bind_parameter_index(&c_name))
     }
 
-    fn bind_parameters<P>(&mut self, params: P) -> Result<()>
+    pub fn bind_parameters<P>(&mut self, params: P) -> Result<()>
     where
         P: IntoIterator,
         P::Item: ToSql,


### PR DESCRIPTION
When implementing a vtable based on an underlying rusqlite connection, we have found it helpful in the `filter` implementation to be able to build a Statement by passing a Vec<Values> to bind_parameters() without actually executing the query (yet). We then convert the Statement into a RawStatement (see #636) and store that on the VTabCursor. Only if our `next` implementation is later called do we actuallt execute the query (by calling `step()` on the raw statement). 