### PR TITLE
don't perform threading mode checks on wasm32

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::ptr;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Mutex};
 
 use super::ffi;
 use super::{str_for_sqlite, str_to_cstring};
@@ -324,7 +324,7 @@ impl Drop for InnerConnection {
 }
 
 #[cfg(not(feature = "bundled"))]
-static SQLITE_VERSION_CHECK: Once = Once::new();
+static SQLITE_VERSION_CHECK: std::sync::Once = std::sync::Once::new();
 #[cfg(not(feature = "bundled"))]
 pub static BYPASS_VERSION_CHECK: AtomicBool = AtomicBool::new(false);
 
@@ -372,9 +372,25 @@ rusqlite was built against SQLite {} but the runtime SQLite version is {}. To fi
     });
 }
 
-static SQLITE_INIT: Once = Once::new();
+#[cfg(not(any(
+    target_arch = "wasm32"
+)))]
+static SQLITE_INIT: std::sync::Once = std::sync::Once::new();
+
 pub static BYPASS_SQLITE_INIT: AtomicBool = AtomicBool::new(false);
 
+// threading mode checks are not necessary (and do not work) on target
+// platforms that do not have threading (such as webassembly)
+#[cfg(any(
+    target_arch = "wasm32"
+))]
+fn ensure_safe_sqlite_threading_mode() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_arch = "wasm32"
+)))]
 fn ensure_safe_sqlite_threading_mode() -> Result<()> {
     // Ensure SQLite was compiled in thredsafe mode.
     if unsafe { ffi::sqlite3_threadsafe() == 0 } {


### PR DESCRIPTION
The wasm32 target arch does not support threads, and to compile the sqlite core for wasm32 requires setting `SQLITE_OS_OTHER`, which does not include a mutex implementation, meaning that the checks in `ensure_safe_sqlite_threading_mode` would always fail. 

This PR disables those checks on the wasm32 target_arch. I've prepared it in such a way (i.e. using an otherwise pointless `any`) as to ease merging with the similar checks included in #631 (see https://github.com/jgallagher/rusqlite/pull/631/files#diff-405160620b5b458acad6ae62a46a20fbR375). 

