### PR TITLE
Allow to set named parameters that are not used in the query

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -452,7 +452,7 @@ impl Statement<'_> {
             if let Some(i) = self.parameter_index(name)? {
                 self.bind_parameter(value, i)?;
             } else {
-                return Err(Error::InvalidParameterName(name.into()));
+                // Parameter is not used in the query; ignore
             }
         }
         Ok(())


### PR DESCRIPTION
I have a situation where a user can write a query, but my program supplies certain parameters they can use in their query. Right now, an error is produced when I try to set parameters the user hasn't referenced in their query. This could be mitigated by first looking up every parameter I try to set and throwing those out that aren't used, but this means additional work.

Not sure if this is the right way to do it or if an additional flag allow_unused_named_parameters should be added to the functions/a new set of functions...