### PR TITLE
Add playground metadata for `rusqlite`, hopefully fixing it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,7 @@ features = [ "backup", "blob", "chrono", "collation", "functions", "limits", "lo
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
+
+[package.metadata.playground]
+features = ["array", "backup", "blob", "bundled", "chrono", "collation", "csvtab", "extra_check", "functions", "hooks", "i128_blob", "limits", "load_extension", "modern_sqlite", "serde_json", "series", "trace", "url", "vtab_v3", "vtab", "window"]
+all-features = false


### PR DESCRIPTION
Fixes https://github.com/integer32llc/rust-playground/issues/580, hopefully.

I've also turned on all features which don't conflict or cause problems, since most are small anyway and it would be annoying not to have user defined function support.

