### PR TITLE
Remove use of `time` crate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgre
 
 ```rust
 use rusqlite::{params, Connection, Result};
-use time::Timespec;
 
 #[derive(Debug)]
 struct Person {
     id: i32,
     name: String,
-    time_created: Timespec,
     data: Option<Vec<u8>>,
 }
 
@@ -29,7 +27,6 @@ fn main() -> Result<()> {
         "CREATE TABLE person (
                   id              INTEGER PRIMARY KEY,
                   name            TEXT NOT NULL,
-                  time_created    TEXT NOT NULL,
                   data            BLOB
                   )",
         params![],
@@ -37,22 +34,19 @@ fn main() -> Result<()> {
     let me = Person {
         id: 0,
         name: "Steven".to_string(),
-        time_created: time::get_time(),
         data: None,
     };
     conn.execute(
-        "INSERT INTO person (name, time_created, data)
-                  VALUES (?1, ?2, ?3)",
-        params![me.name, me.time_created, me.data],
+        "INSERT INTO person (name, data) VALUES (?1, ?2)",
+        params![me.name, me.data],
     )?;
 
-    let mut stmt = conn.prepare("SELECT id, name, time_created, data FROM person")?;
+    let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
     let person_iter = stmt.query_map(params![], |row| {
         Ok(Person {
             id: row.get(0)?,
             name: row.get(1)?,
-            time_created: row.get(2)?,
-            data: row.get(3)?,
+            data: row.get(2)?,
         })
     })?;
 


### PR DESCRIPTION
We'll be making this a feature when we get around to #653, so it's probably not best to have used directly in the readme anyway.

Fixes #625.