### PR TITLE
Relaxed Sized bound on Box/Rc/Arc/Cow for ToSql

### DIFF
--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -101,15 +101,13 @@ impl<T: ToSql + ?Sized> ToSql for Box<T> {
 
 impl<T: ToSql> ToSql for std::rc::Rc<T> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        let derefed: &dyn ToSql = &**self;
-        derefed.to_sql()
+        self.as_ref().to_sql()
     }
 }
 
 impl<T: ToSql> ToSql for std::sync::Arc<T> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        let derefed: &dyn ToSql = &**self;
-        derefed.to_sql()
+        self.as_ref().to_sql()
     }
 }
 

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -229,7 +229,23 @@ mod test {
     }
 
     #[test]
-    fn test_box() {
+    fn test_box_dyn() {
+        let s: Box<dyn ToSql> = Box::new("Hello world!");
+        let r = ToSql::to_sql(&s);
+
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_box_deref() {
+        let s: Box<str> = "Hello world!".into();
+        let r = s.to_sql();
+
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_box_direct() {
         let s: Box<str> = "Hello world!".into();
         let r = ToSql::to_sql(&s);
 

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -87,7 +87,7 @@ pub trait ToSql {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>>;
 }
 
-impl<T: ToSql + Clone> ToSql for Cow<'_, T> {
+impl<T: ToSql + Clone + ?Sized> ToSql for Cow<'_, T> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
         self.as_ref().to_sql()
     }
@@ -99,13 +99,13 @@ impl<T: ToSql + ?Sized> ToSql for Box<T> {
     }
 }
 
-impl<T: ToSql> ToSql for std::rc::Rc<T> {
+impl<T: ToSql + ?Sized> ToSql for std::rc::Rc<T> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
         self.as_ref().to_sql()
     }
 }
 
-impl<T: ToSql> ToSql for std::sync::Arc<T> {
+impl<T: ToSql + ?Sized> ToSql for std::sync::Arc<T> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
         self.as_ref().to_sql()
     }


### PR DESCRIPTION
In https://github.com/jgallagher/rusqlite/pull/660 I added support for `Box<T>` where `T: ToSql`.
But as I see it does not work with unsized types. Instead of impl for `Box<dyn ToSql>` above is used.

I tried to put my `Box<str>` in `ToSql::to_sql(**here**)` but it tells me that `str` is unsized.
I think there must be impl `ToSql + ?Sized` for `Box<T>` instead of `T: ToSql`. And I also removed impl for `Box<dyn ToSql>` because it conflicts (and didn't work before with my example) with my new impl.