### PR TITLE
Add in_gecko feature to libsqlite3-sys to bypass linking / perform the (currently minor) changes needed to integrate 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ series = ["vtab"]
 extra_check = []
 modern_sqlite = ["libsqlite3-sys/bundled_bindings"]
 unstable = []
+in_gecko = ["modern_sqlite", "libsqlite3-sys/in_gecko"]
 
 [dependencies]
 time = "0.1.0"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -30,6 +30,7 @@ unlock_notify = []
 preupdate_hook = []
 # 3.13.0
 session = ["preupdate_hook"]
+in_gecko = []
 
 [build-dependencies]
 bindgen = { version = "0.53", optional = true, default-features = false, features = ["runtime"] }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -4,6 +4,13 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir).join("bindgen.rs");
+    if cfg!(feature = "in_gecko") {
+        // When inside mozilla-central, we are included into the build with
+        // sqlite3.o directly, so we don't want to provide any linker arguments.
+        std::fs::copy("sqlite3/bindgen_bundled_version.rs", out_path)
+            .expect("Could not copy bindings to output directory");
+        return;
+    }
     if cfg!(feature = "sqlcipher") {
         if cfg!(any(
             feature = "bundled",


### PR DESCRIPTION
We're vendoring libsqlite3-sys (well, rusqlite in general) into mozilla-central to be part of the rest of the gecko/firefox build system.

In this configuration, we need to use our local build of sqlite, which just means we want to skip linking like this.

@gwenn Just to make sure, this is a moz-specific change but it seems pretty minor and unlikely to cause undue difficulty with maintenance.

I didn't make it a general bypass-linking feature, but if there's interest in the future I'd be willing to do so. The main difference would be making buildtime-bindgen and such work, which I don't need and would need special code for working inside mozbuild.

After this lands I'll take the steps to cut a point release of libsqlite3-sys.