### PR TITLE
Prep for libsqlite3-sys 0.17.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ unicase = "2.4.0"
 
 [dependencies.libsqlite3-sys]
 path = "libsqlite3-sys"
-version = "0.18"
+version = "0.17.2"
 
 [[test]]
 name = "config_log"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.17.2"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 edition = "2018"
 repository = "https://github.com/jgallagher/rusqlite"


### PR DESCRIPTION
This is essentially to get a release out that contains `in_gecko` so that this library can be used in Firefox.

Note: This had temporarily been 0.18.0, but as noted in https://github.com/jgallagher/rusqlite/pull/619#discussion_r370435032 there isn't an actual need for this, as it isn't a breaking change.

By releasing it as 0.17.2, users can still link rusqlite 0.21.0 against it, which lets us avoid needing to cut a release of rusqlite just for a gecko-specific linkage flag (Admittedly, there are other features people might want -- I'm being conservative by avoiding this, but maybe it's unnecessary).

@gwenn I'll leave this up for a bit, and probably merge it and do the crates.io release tomorrow morning (Pacific time US) if you have no objections before then (LMK if you'd like more time to think about it or whatever).

Alternatively we could cut 0.18.0 of libsqlite3-sys and another release of rusqlite. I don't know if the next rusqlite release is breaking or not. I believe #660 (or maybe it was #662) is technically breaking (you indicated that it caused the bustage that #664 resolved), but is considered a minor change by https://rust-lang.github.io/rfcs/1105-api-evolution.html#minor-change-generalizing-to-generics... But I haven't thought about other changes, and don't know what all you want to get in.

That said, nothing prevents us from doing this, then cutting a rusqlite release later, of course