### PR TITLE
Clarify that the submodules of `rusqlite::vtab` are ports

### DIFF
--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -1,9 +1,10 @@
-//! `feature = "array"` Array Virtual Table: https://www.sqlite.org/carray.html
+//! `feature = "array"` Array Virtual Table.
 //!
 //! Note: `rarray`, not `carray` is the name of the table valued function we
 //! define.
 //!
-//! Port of [carray](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/carray.c) C extension.
+//! Port of [carray](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/carray.c)
+//! C extension: https://www.sqlite.org/carray.html
 //!
 //! # Example
 //!

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -1,6 +1,7 @@
-//! `feature = "csvtab"` CSV Virtual Table: https://www.sqlite.org/csv.html
+//! `feature = "csvtab"` CSV Virtual Table.
 //!
-//! Port of [csv](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/csv.c) C extension.
+//! Port of [csv](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/csv.c) C
+//! extension: https://www.sqlite.org/csv.html
 //!
 //! # Example
 //!

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -1,6 +1,8 @@
-//! `feature = "series"` Generate series virtual table: https://www.sqlite.org/series.html
+//! `feature = "series"` Generate series virtual table.
 //!
-//! Port of C [generate series "function"](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/series.c).
+//! Port of C [generate series
+//! "function"](http://www.sqlite.org/cgi/src/finfo?name=ext/misc/series.c):
+//! https://www.sqlite.org/series.html
 use std::default::Default;
 use std::os::raw::c_int;
 


### PR DESCRIPTION
See https://github.com/jgallagher/rusqlite/pull/669#discussion_r404271816 and related comments.

Does this seem better to you?