### PR TITLE
Add `#[non_exhaustive]` to enums that might get new variants.

### DIFF
--- a/libsqlite3-sys/src/error.rs
+++ b/libsqlite3-sys/src/error.rs
@@ -4,6 +4,7 @@ use std::os::raw::c_int;
 
 /// Error Codes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// Internal logic error in SQLite
     InternalMalfunction,

--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -17,6 +17,7 @@ pub fn SQLITE_TRANSIENT() -> sqlite3_destructor_type {
 
 /// Run-Time Limit Categories
 #[repr(i32)]
+#[non_exhaustive]
 pub enum Limit {
     /// The maximum size of any string or BLOB or table row, in bytes.
     SQLITE_LIMIT_LENGTH = SQLITE_LIMIT_LENGTH,

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -132,6 +132,7 @@ impl Connection {
 
 /// `feature = "backup"` Possible successful results of calling `Backup::step`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StepResult {
     /// The backup is complete.
     Done,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use crate::{Connection, Result};
 /// Database Connection Configuration Options
 #[repr(i32)]
 #[allow(non_snake_case, non_camel_case_types)]
+#[non_exhaustive]
 pub enum DbConfig {
     //SQLITE_DBCONFIG_MAINDBNAME = 1000, /* const char* */
     //SQLITE_DBCONFIG_LOOKASIDE = 1001,  /* void* int int */

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use std::str;
 /// Enum listing possible errors from rusqlite.
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
 pub enum Error {
     /// An error from an underlying SQLite call.
     SqliteFailure(ffi::Error, Option<String>),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -12,6 +12,7 @@ use crate::{Connection, InnerConnection};
 /// `feature = "hooks"` Action Codes
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum Action {
     UNKNOWN = -1,
     SQLITE_DELETE = ffi::SQLITE_DELETE,

--- a/src/session.rs
+++ b/src/session.rs
@@ -638,6 +638,7 @@ impl Connection {
 /// `feature = "session"` Constants passed to the conflict handler
 #[repr(i32)]
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ConflictType {
     UNKNOWN = -1,
     SQLITE_CHANGESET_DATA = ffi::SQLITE_CHANGESET_DATA,
@@ -662,6 +663,7 @@ impl From<i32> for ConflictType {
 /// `feature = "session"` Constants returned by the conflict handler
 #[repr(i32)]
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ConflictAction {
     SQLITE_CHANGESET_OMIT = ffi::SQLITE_CHANGESET_OMIT,
     SQLITE_CHANGESET_REPLACE = ffi::SQLITE_CHANGESET_REPLACE,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -822,6 +822,7 @@ impl Statement<'_> {
 /// may not be available.
 #[repr(i32)]
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StatementStatus {
     /// Equivalent to SQLITE_STMTSTATUS_FULLSCAN_STEP
     FullscanStep = 1,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 /// Options for transaction behavior. See [BEGIN
 /// TRANSACTION](http://www.sqlite.org/lang_transaction.html) for details.
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub enum TransactionBehavior {
     Deferred,
     Immediate,
@@ -12,6 +13,7 @@ pub enum TransactionBehavior {
 
 /// Options for how a Transaction or Savepoint should behave when it is dropped.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DropBehavior {
     /// Roll back the changes. This is the default.
     Rollback,

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 /// Enum listing possible errors from `FromSql` trait.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FromSqlError {
     /// Error when an SQLite value is requested, but the type of the result
     /// cannot be converted to the requested Rust type.

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 /// `ToSqlOutput` represents the possible output types for implementors of the
 /// `ToSql` trait.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ToSqlOutput<'a> {
     /// A borrowed SQLite-representable value.
     Borrowed(ValueRef<'a>),

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -247,6 +247,7 @@ pub trait CreateVTab: VTab {
 /// `feature = "vtab"` Index constraint operator.
 #[derive(Debug, PartialEq)]
 #[allow(non_snake_case, non_camel_case_types)]
+#[non_exhaustive]
 pub enum IndexConstraintOp {
     SQLITE_INDEX_CONSTRAINT_EQ,
     SQLITE_INDEX_CONSTRAINT_GT,


### PR DESCRIPTION
This just using them in patterns without a catchall. I left things alone
that seem very unlikely to change (`Value`, `ValueRef`, `DatabaseName`,
etc...). This might help reduce the number of breaking changes we need


rusqlite is still pre-1.0 so it doesn't really matter that much, but
breaking changes complicate the story around when we can safely cut releases.