### PR TITLE
Add `Rows::{mapped,and_then}` to get an Iterator out of a Rows instance

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -41,6 +41,25 @@ impl<'stmt> Rows<'stmt> {
     {
         Map { rows: self, f }
     }
+
+    /// Map over this `Rows`, converting it to a [`MappedRows`], which
+    /// implements `Iterator`.
+    pub fn mapped<F, B>(self, f: F) -> MappedRows<'stmt, F>
+    where
+        F: FnMut(&Row<'_>) -> Result<B>,
+    {
+        MappedRows { rows: self, map: f }
+    }
+
+    /// Map over this `Rows` with a fallible function, converting it to a
+    /// [`AndThenRows`], which implements `Iterator` (instead of
+    /// `FallibleStreamingIterator`).
+    pub fn and_then<F, T, E>(self, f: F) -> AndThenRows<'stmt, F>
+    where
+        F: FnMut(&Row<'_>) -> result::Result<T, E>,
+    {
+        AndThenRows { rows: self, map: f }
+    }
 }
 
 impl<'stmt> Rows<'stmt> {


### PR DESCRIPTION
Tiny piece of functionality I've wanted. The difference between `row::Map` and `MappedRows` is a bit confusing now. I guess one is `Option<Result<T, E>>` and the other `Result<Option<T>, E>`.

I think we could probably remove `Map` (and possibly the dependency on FallibleIterator? I think this is the only use), but didn't want to do this without understanding it's use case more.