### PR TITLE
Run clippy on all-targets. Also, use --workspace instead of --all

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           RUSTFLAGS: -D warnings
         with:
           command: clippy
-          args: --features 'array backup blob bundled chrono collation csvtab extra_check functions hooks i128_blob limits load_extension serde_json series trace url vtab_v3 window' -- -D warnings
+          args: --all-targets --all --features 'array backup blob bundled chrono collation csvtab extra_check functions hooks i128_blob limits load_extension serde_json series trace url vtab_v3 window' -- -D warnings
 
   # Ensure patch is formatted.
   fmt:


### PR DESCRIPTION
The changes in #670 failed to lint tests and such.