### PR TITLE
Allow optionally passing an Error parameter to `rusqlite::Result`

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,6 @@
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
-use std::{convert, result};
+use std::convert;
 
 use super::{Error, Result, Statement};
 use crate::types::{FromSql, FromSqlError, ValueRef};
@@ -56,7 +56,7 @@ impl<'stmt> Rows<'stmt> {
     /// `FallibleStreamingIterator`).
     pub fn and_then<F, T, E>(self, f: F) -> AndThenRows<'stmt, F>
     where
-        F: FnMut(&Row<'_>) -> result::Result<T, E>,
+        F: FnMut(&Row<'_>) -> Result<T, E>,
     {
         AndThenRows { rows: self, map: f }
     }
@@ -143,7 +143,7 @@ pub struct AndThenRows<'stmt, F> {
 
 impl<'stmt, T, E, F> AndThenRows<'stmt, F>
 where
-    F: FnMut(&Row<'_>) -> result::Result<T, E>,
+    F: FnMut(&Row<'_>) -> Result<T, E>,
 {
     pub(crate) fn new(rows: Rows<'stmt>, f: F) -> AndThenRows<'stmt, F> {
         AndThenRows { rows, map: f }
@@ -153,9 +153,9 @@ where
 impl<T, E, F> Iterator for AndThenRows<'_, F>
 where
     E: convert::From<Error>,
-    F: FnMut(&Row<'_>) -> result::Result<T, E>,
+    F: FnMut(&Row<'_>) -> Result<T, E>,
 {
-    type Item = result::Result<T, E>;
+    type Item = Result<T, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let map = &mut self.map;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -3,7 +3,7 @@ use std::os::raw::{c_int, c_void};
 #[cfg(feature = "array")]
 use std::rc::Rc;
 use std::slice::from_raw_parts;
-use std::{convert, fmt, mem, ptr, result, str};
+use std::{convert, fmt, mem, ptr, str};
 
 use super::ffi;
 use super::{len_as_c_int, str_for_sqlite, str_to_cstring};
@@ -284,7 +284,7 @@ impl Statement<'_> {
         P: IntoIterator,
         P::Item: ToSql,
         E: convert::From<Error>,
-        F: FnMut(&Row<'_>) -> result::Result<T, E>,
+        F: FnMut(&Row<'_>) -> Result<T, E>,
     {
         let rows = self.query(params)?;
         Ok(AndThenRows::new(rows, f))
@@ -335,7 +335,7 @@ impl Statement<'_> {
     ) -> Result<AndThenRows<'_, F>>
     where
         E: convert::From<Error>,
-        F: FnMut(&Row<'_>) -> result::Result<T, E>,
+        F: FnMut(&Row<'_>) -> Result<T, E>,
     {
         let rows = self.query_named(params)?;
         Ok(AndThenRows::new(rows, f))

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -24,7 +24,6 @@
 use std::fs::File;
 use std::os::raw::c_int;
 use std::path::Path;
-use std::result;
 use std::str;
 
 use crate::ffi;
@@ -70,7 +69,7 @@ struct CSVTab {
 }
 
 impl CSVTab {
-    fn reader(&self) -> result::Result<csv::Reader<File>, csv::Error> {
+    fn reader(&self) -> Result<csv::Reader<File>, csv::Error> {
         csv::ReaderBuilder::new()
             .has_headers(self.has_headers)
             .delimiter(self.delimiter)


### PR DESCRIPTION
If not passed, by default it will be rusqlite::Error, as before (this is non-breaking). This avoids having to do `std::result::Result<T, E>` if you've brought rusqlite::Result into scope.