### PR TITLE
Prepare 0.22.0-beta.0 (prerelease/unstable/testing build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.21.0"
+version = "0.22.0-beta.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite"


### PR DESCRIPTION
I'm going to do a beta/prerelease of 0.22.0 so I can ensure I've worked all the build issues out with moz-central integration.

Might do another even later today if needed...