### PR TITLE
Clean up internal unsafe code

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -77,8 +77,8 @@ impl Connection {
 
         match r {
             Done => Ok(()),
-            Busy => Err(error_from_handle(ptr::null_mut(), ffi::SQLITE_BUSY)),
-            Locked => Err(error_from_handle(ptr::null_mut(), ffi::SQLITE_LOCKED)),
+            Busy => Err(unsafe { error_from_handle(ptr::null_mut(), ffi::SQLITE_BUSY) }),
+            Locked => Err(unsafe { error_from_handle(ptr::null_mut(), ffi::SQLITE_LOCKED) }),
             More => unreachable!(),
         }
     }
@@ -123,8 +123,8 @@ impl Connection {
 
         match r {
             Done => Ok(()),
-            Busy => Err(error_from_handle(ptr::null_mut(), ffi::SQLITE_BUSY)),
-            Locked => Err(error_from_handle(ptr::null_mut(), ffi::SQLITE_LOCKED)),
+            Busy => Err(unsafe { error_from_handle(ptr::null_mut(), ffi::SQLITE_BUSY) }),
+            Locked => Err(unsafe { error_from_handle(ptr::null_mut(), ffi::SQLITE_LOCKED) }),
             More => unreachable!(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -357,11 +357,11 @@ pub fn error_from_sqlite_code(code: c_int, message: Option<String>) -> Error {
     Error::SqliteFailure(ffi::Error::new(code), message)
 }
 
-pub fn error_from_handle(db: *mut ffi::sqlite3, code: c_int) -> Error {
+pub unsafe fn error_from_handle(db: *mut ffi::sqlite3, code: c_int) -> Error {
     let message = if db.is_null() {
         None
     } else {
-        Some(unsafe { errmsg_to_string(ffi::sqlite3_errmsg(db)) })
+        Some(errmsg_to_string(ffi::sqlite3_errmsg(db)))
     };
     error_from_sqlite_code(code, message)
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -102,7 +102,7 @@ impl InnerConnection {
         // `sqlite3_commit_hook`. so we keep the `xDestroy` function in
         // `InnerConnection.free_boxed_hook`.
         let free_commit_hook = if hook.is_some() {
-            Some(free_boxed_hook::<F> as fn(*mut c_void))
+            Some(free_boxed_hook::<F> as unsafe fn(*mut c_void))
         } else {
             None
         };
@@ -122,7 +122,7 @@ impl InnerConnection {
         };
         if !previous_hook.is_null() {
             if let Some(free_boxed_hook) = self.free_commit_hook {
-                free_boxed_hook(previous_hook);
+                unsafe { free_boxed_hook(previous_hook) };
             }
         }
         self.free_commit_hook = free_commit_hook;
@@ -143,7 +143,7 @@ impl InnerConnection {
         }
 
         let free_rollback_hook = if hook.is_some() {
-            Some(free_boxed_hook::<F> as fn(*mut c_void))
+            Some(free_boxed_hook::<F> as unsafe fn(*mut c_void))
         } else {
             None
         };
@@ -163,7 +163,7 @@ impl InnerConnection {
         };
         if !previous_hook.is_null() {
             if let Some(free_boxed_hook) = self.free_rollback_hook {
-                free_boxed_hook(previous_hook);
+                unsafe { free_boxed_hook(previous_hook) };
             }
         }
         self.free_rollback_hook = free_rollback_hook;
@@ -202,7 +202,7 @@ impl InnerConnection {
         }
 
         let free_update_hook = if hook.is_some() {
-            Some(free_boxed_hook::<F> as fn(*mut c_void))
+            Some(free_boxed_hook::<F> as unsafe fn(*mut c_void))
         } else {
             None
         };
@@ -222,15 +222,15 @@ impl InnerConnection {
         };
         if !previous_hook.is_null() {
             if let Some(free_boxed_hook) = self.free_update_hook {
-                free_boxed_hook(previous_hook);
+                unsafe { free_boxed_hook(previous_hook) };
             }
         }
         self.free_update_hook = free_update_hook;
     }
 }
 
-fn free_boxed_hook<F>(p: *mut c_void) {
-    drop(unsafe { Box::from_raw(p as *mut F) });
+unsafe fn free_boxed_hook<F>(p: *mut c_void) {
+    drop(Box::from_raw(p as *mut F));
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1028,25 +1028,23 @@ mod test {
         // statement first.
         let raw_stmt = {
             use super::str_to_cstring;
-            use std::mem::MaybeUninit;
             use std::os::raw::c_int;
             use std::ptr;
 
             let raw_db = db.db.borrow_mut().db;
             let sql = "SELECT 1";
-            let mut raw_stmt = MaybeUninit::uninit();
+            let mut raw_stmt: *mut ffi::sqlite3_stmt = ptr::null_mut();
             let cstring = str_to_cstring(sql).unwrap();
             let rc = unsafe {
                 ffi::sqlite3_prepare_v2(
                     raw_db,
                     cstring.as_ptr(),
                     (sql.len() + 1) as c_int,
-                    raw_stmt.as_mut_ptr(),
+                    &mut raw_stmt,
                     ptr::null_mut(),
                 )
             };
             assert_eq!(rc, ffi::SQLITE_OK);
-            let raw_stmt: *mut ffi::sqlite3_stmt = unsafe { raw_stmt.assume_init() };
             raw_stmt
         };
 

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -10,7 +10,7 @@ use std::ptr;
 pub struct RawStatement(*mut ffi::sqlite3_stmt, bool);
 
 impl RawStatement {
-    pub fn new(stmt: *mut ffi::sqlite3_stmt, tail: bool) -> RawStatement {
+    pub unsafe fn new(stmt: *mut ffi::sqlite3_stmt, tail: bool) -> RawStatement {
         RawStatement(stmt, tail)
     }
 
@@ -64,10 +64,10 @@ impl RawStatement {
             let mut rc;
             loop {
                 rc = unsafe { ffi::sqlite3_step(self.0) };
-                if !unlock_notify::is_locked(db, rc) {
+                if unsafe { !unlock_notify::is_locked(db, rc) } {
                     break;
                 }
-                rc = unlock_notify::wait_for_unlock_notify(db);
+                rc = unsafe { unlock_notify::wait_for_unlock_notify(db) };
                 if rc != ffi::SQLITE_OK {
                     break;
                 }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -619,7 +619,7 @@ impl Statement<'_> {
     }
 
     fn finalize_(&mut self) -> Result<()> {
-        let mut stmt = RawStatement::new(ptr::null_mut(), false);
+        let mut stmt = unsafe { RawStatement::new(ptr::null_mut(), false) };
         mem::swap(&mut stmt, &mut self.stmt);
         self.conn.decode_result(stmt.finalize())
     }
@@ -710,7 +710,7 @@ impl Statement<'_> {
 
 impl Into<RawStatement> for Statement<'_> {
     fn into(mut self) -> RawStatement {
-        let mut stmt = RawStatement::new(ptr::null_mut(), false);
+        let mut stmt = unsafe { RawStatement::new(ptr::null_mut(), false) };
         mem::swap(&mut stmt, &mut self.stmt);
         stmt
     }


### PR DESCRIPTION
1. Ensure every function that dereferences a pointer or could otherwise lead to memory safety is marked as `unsafe`

    None of this was public and the public API appears sound so it's not really a big deal, but it makes auditing easier (and avoids people getting angry the way they did for actix... :/)

2. Avoid using MaybeUninit for pointers. There's really no perf benefit here and it's UB if something was ever not fully initialized by sqlite. Not worth it.