### PR TITLE
Avoid rust-analyzer bug in InnerConnection::new

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -36,24 +36,16 @@ pub struct InnerConnection {
 }
 
 impl InnerConnection {
-    #[cfg(not(feature = "hooks"))]
     #[allow(clippy::mutex_atomic)]
     pub fn new(db: *mut ffi::sqlite3, owned: bool) -> InnerConnection {
         InnerConnection {
             db,
             interrupt_lock: Arc::new(Mutex::new(db)),
-            owned,
-        }
-    }
-
-    #[cfg(feature = "hooks")]
-    #[allow(clippy::mutex_atomic)]
-    pub fn new(db: *mut ffi::sqlite3, owned: bool) -> InnerConnection {
-        InnerConnection {
-            db,
-            interrupt_lock: Arc::new(Mutex::new(db)),
+            #[cfg(feature = "hooks")]
             free_commit_hook: None,
+            #[cfg(feature = "hooks")]
             free_rollback_hook: None,
+            #[cfg(feature = "hooks")]
             free_update_hook: None,
             owned,
         }


### PR DESCRIPTION
This is a workaround for a false error rust-analyzer gives in
InnerConnection::new. I'm guessing it's because it does some weird
feature stuff. It doesn't change any semantics, but makes working in
`rusqlite` much nicer when using rust-analyzer.

I vaguely remember RLS having the same error too, actually.