### PR TITLE
Revert "Merge pull request #499 from xfix/unix-invalid-unicode"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,13 +265,6 @@ fn len_as_c_int(len: usize) -> Result<c_int> {
     }
 }
 
-#[cfg(unix)]
-fn path_to_cstring(p: &Path) -> Result<CString> {
-    use std::os::unix::ffi::OsStrExt;
-    Ok(CString::new(p.as_os_str().as_bytes())?)
-}
-
-#[cfg(not(unix))]
 fn path_to_cstring(p: &Path) -> Result<CString> {
     let s = p.to_str().ok_or_else(|| Error::InvalidPath(p.to_owned()))?;
     str_to_cstring(s)
@@ -893,17 +886,7 @@ unsafe fn db_filename(db: *mut ffi::sqlite3) -> Option<PathBuf> {
     if db_filename.is_null() {
         None
     } else {
-        let cstr = CStr::from_ptr(db_filename);
-        #[cfg(unix)]
-        {
-            use std::ffi::OsStr;
-            use std::os::unix::ffi::OsStrExt;
-            Some(OsStr::from_bytes(cstr.to_bytes()).into())
-        }
-        #[cfg(not(unix))]
-        {
-            cstr.to_str().ok().map(PathBuf::from)
-        }
+        CStr::from_ptr(db_filename).to_str().ok().map(PathBuf::from)
     }
 }
 #[cfg(not(feature = "modern_sqlite"))]
@@ -1003,35 +986,6 @@ mod test {
 
         let path_string = path.to_str().unwrap();
         let db = Connection::open(&path_string).unwrap();
-        let the_answer: Result<i64> = db.query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0));
-
-        assert_eq!(42i64, the_answer.unwrap());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_invalid_unicode_file_names() {
-        use std::ffi::OsStr;
-        use std::fs::File;
-        use std::os::unix::ffi::OsStrExt;
-        let temp_dir = TempDir::new("test_invalid_unicode").unwrap();
-        let path = temp_dir.path();
-        if File::create(path.join(OsStr::from_bytes(&[0xFE]))).is_err() {
-            // Skip test, filesystem doesn't support invalid Unicode
-            return;
-        }
-        let db_path = path.join(OsStr::from_bytes(&[0xFF]));
-
-        {
-            let db = Connection::open(&db_path).unwrap();
-            let sql = "BEGIN;
-                   CREATE TABLE foo(x INTEGER);
-                   INSERT INTO foo VALUES(42);
-                   END;";
-            db.execute_batch(sql).unwrap();
-        }
-
-        let db = Connection::open(&db_path).unwrap();
         let the_answer: Result<i64> = db.query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0));
 
         assert_eq!(42i64, the_answer.unwrap());


### PR DESCRIPTION
This reverts commit 061748e1f5ad3b556958c2d2b8badfd32edb2b81, reversing
changes made to cf3cdecf1290c8595087f354b29b2c4ff2d2b645.

Too hasty, this doesn't build on unix. @xfix please feel free to resubmit after you fix. CI should now report unix errors properly