### PR TITLE
Prep rusqlite 0.22.0 and libsqlite3-sys 0.17.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.22.0-beta.0"
+version = "0.22.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite"
@@ -113,7 +113,7 @@ bencher = "0.1"
 
 [dependencies.libsqlite3-sys]
 path = "libsqlite3-sys"
-version = "0.17.2"
+version = "0.17.3"
 
 [[test]]
 name = "config_log"

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsqlite3-sys"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
 edition = "2018"
 repository = "https://github.com/jgallagher/rusqlite"


### PR DESCRIPTION
Fixes #674 

Will land this and cut and tag the releases after lunch unless there are objections.

Planned changelog (partially taken from @gwenn draft release notes):

* Add ability to open sqlite connection with specified vfs (#630)
* Fix i32 overflow in `Connection::busy_timeout` (#604)
* Separate the `modern_sqlite` and `bundled` features. (#613)
* Add `FromSql` for `Box<str>`, `Rc<str>` and `Arc<str>`
* Fix params macro (#614)
* Fix error while executing ALTER statement (#645)
* Ignore PATH change (#435)
* Add playground metadata for `rusqlite`, hopefully fixing it (#647)
* Don't perform threading mode checks on wasm32 (#640)
* Upgraded the bundled SQLite version to 3.31.0. (#619)
* Add support to function flags (#622)
* Add missing `IndexConstraintOp` entries (#623)
* Add missing error codes (#624)
* Add missing constants (#629)
* Introduce `alloc` to generate C string allocated by sqlite3 (#644)
* `rusqlite` now exposes the `bundled-windows` feature, forwarding to `libsqlite3-sys`. (#682)
* `rusqlite::Result<T>` is now defined as `type Result<T, E = rusqlite::Error>`. This avoids needing to access `std::result::Result` explicitly when `rusqlite::Result` is brought into scope. (#678)
* `Rows` now support `mapped` and `and_then` functions which return Iterators. This is useful if you cannot use `query_map` or `query_and_then` for some reason. (#676)
* A new error variant was added for using the wrong number of bound parameters. Previously this caused a panic (#675).
* Many rusqlite enums have been made `#[non_exhaustive]` for better extensibility. (#673)
* Various low-level `Statement` apis have been added to allow separating parameter binding and statement execution. (#668)
* ToSql is implemented for various smart pointers (Box, Cow, Rc, Arc) in more cases. (#660)
* `bundled-full` feature now exists to enable both `bundled` and other features which do not conflict. It is mainly intended to improve developer ergonomics for working on rusqlite (#687)
* The features `vtab_v3` and `unstable` are removed. The former is no longer necessary and the latter was only used for `#[bench]`. (#687)
* `rusqlite::Error` now implements `std::error::Error::source` instead of only `std::error::Error::cause`. Use of `cause` will still work, as it goes through `source` by default. (#683)
