### PR TITLE
Misc CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: stable
+          targets: ${{ matrix.platform.target }}
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,8 @@ jobs:
           toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -D warnings
         with:
-          command: doc
-          args: --no-deps --features 'bundled-full session buildtime_bindgen'
+          # Need to use `cargo rustdoc` to actually get it to respect -D
+          # warnings... Note: this also requires nightly.
+          command: rustdoc
+          args: --features 'bundled-full session buildtime_bindgen' -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,19 +77,15 @@ jobs:
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -D warnings
         with:
           command: clippy
           # clippy with just bundled
-          args: --all-targets --workspace --features bundled
+          args: --all-targets --workspace --features bundled -- -D warnings
       - uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -D warnings
         with:
           command: clippy
           # Clippy with all non-conflicting features
-          args: --all-targets --workspace --features 'bundled-full session buildtime_bindgen'
+          args: --all-targets --workspace --features 'bundled-full session buildtime_bindgen' -- -D warnings
 
   # Ensure patch is formatted.
   fmt:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           args: --features bundled --workspace --all-targets
 
       - name: "cargo test --features 'bundled-full session buildtime_bindgen'"
+        # TODO: clang is installed on these -- but `bindgen` can't find it...
         if: matrix.platform.os != 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
@@ -52,7 +53,6 @@ jobs:
           args: --features 'bundled-full session buildtime_bindgen' --all-targets --workspace
 
       - name: "cargo test --features bundled-full"
-        if: matrix.platform.os == 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches:
       - master
-
+  schedule:
+    - cron: '00 01 * * *'
 jobs:
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
 #          - { target: x86_64-pc-windows-gnu, os: windows-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: x86_64-apple-darwin, os: macos-latest }
 
     runs-on: ${{ matrix.platform.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      # This has a matcher for test panics, so we use it even though elsewhere
+      # we use actions-rs/toolchain.
+      - uses: hecrj/setup-rust-action@v1
         with:
-          target: ${{ matrix.platform.target }}
-          default: true
-          profile: minimal
-          toolchain: stable
-          override: true
+          rust-version: stable
 
       - uses: actions-rs/cargo@v1
         with:
@@ -99,11 +97,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      # This has a matcher for rustfmt errors, so we use it even though
+      # elsewhere we use actions-rs/toolchain.
+      - uses: hecrj/setup-rust-action@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          rust-version: stable
+          components: rustfmt
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
- Missed a checkout in #698 
- `cargo doc` ignores -D warnings (`cargo rustdoc` doesn't)
- `hecrj/setup-rust-action` has matchers for rustfmt errors and panics, so use that in cases where we expect those.
- Run CI on a cron schedule to avoid cases where we have lint/fmt errors without knowing.
- Run CI for macos
- Run bundled-full tests on windows (in theory we can test buildtime bindgen but I need to figure out where libclang is installed to).