### PR TITLE
Fix vtab::Module lifetime

### DIFF
--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -71,7 +71,7 @@ struct ArrayTab {
     base: ffi::sqlite3_vtab,
 }
 
-impl VTab for ArrayTab {
+unsafe impl VTab for ArrayTab {
     type Aux = ();
     type Cursor = ArrayTabCursor;
 
@@ -149,7 +149,7 @@ impl ArrayTabCursor {
         }
     }
 }
-impl VTabCursor for ArrayTabCursor {
+unsafe impl VTabCursor for ArrayTabCursor {
     fn filter(&mut self, idx_num: c_int, _idx_str: Option<&str>, args: &Values<'_>) -> Result<()> {
         if idx_num > 0 {
             self.ptr = args.get_array(0)?;

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -33,8 +33,8 @@ use std::rc::Rc;
 use crate::ffi;
 use crate::types::{ToSql, ToSqlOutput, Value};
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp, IndexInfo, Module, VTab, VTabConnection,
-    VTabCursor, Values,
+    eponymous_only_module, Context, IndexConstraintOp, IndexInfo, VTab, VTabConnection, VTabCursor,
+    Values,
 };
 use crate::{Connection, Result};
 
@@ -57,11 +57,7 @@ impl ToSql for Array {
 /// `feature = "array"` Register the "rarray" module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("rarray", &ARRAY_MODULE, aux)
-}
-
-lazy_static::lazy_static! {
-    static ref ARRAY_MODULE: Module<ArrayTab> = eponymous_only_module::<ArrayTab>(1);
+    conn.create_module("rarray", eponymous_only_module::<ArrayTab>(), aux)
 }
 
 // Column numbers

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,7 +30,7 @@ use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
     dequote, escape_double_quote, parse_boolean, read_only_module, Context, CreateVTab, IndexInfo,
-    Module, VTab, VTabConnection, VTabCursor, Values,
+    VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -47,11 +47,7 @@ use crate::{Connection, Error, Result};
 /// ```
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("csv", &CSV_MODULE, aux)
-}
-
-lazy_static::lazy_static! {
-    static ref CSV_MODULE: Module<CSVTab> = read_only_module::<CSVTab>(1);
+    conn.create_module("csv", read_only_module::<CSVTab>(), aux)
 }
 
 /// An instance of the CSV virtual table

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -95,7 +95,7 @@ impl CSVTab {
     }
 }
 
-impl VTab for CSVTab {
+unsafe impl VTab for CSVTab {
     type Aux = ();
     type Cursor = CSVTabCursor;
 
@@ -296,7 +296,7 @@ impl CSVTabCursor {
     }
 }
 
-impl VTabCursor for CSVTabCursor {
+unsafe impl VTabCursor for CSVTabCursor {
     // Only a full table scan is supported.  So `filter` simply rewinds to
     // the beginning.
     fn filter(

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -189,7 +189,11 @@ impl VTabConnection {
 
 /// `feature = "vtab"` Virtual table instance trait.
 ///
-/// Implementations must be like:
+/// # Safety
+///
+/// The first item in a struct implementing VTab must be
+/// `rusqlite::sqlite3_vtab`, and the struct must be `#[repr(C)]`.
+///
 /// ```rust,ignore
 /// #[repr(C)]
 /// struct MyTab {
@@ -200,7 +204,7 @@ impl VTabConnection {
 /// ```
 ///
 /// (See [SQLite doc](https://sqlite.org/c3ref/vtab.html))
-pub trait VTab: Sized {
+pub unsafe trait VTab: Sized {
     type Aux;
     type Cursor: VTabCursor;
 
@@ -465,7 +469,7 @@ impl OrderBy<'_> {
 /// ```
 ///
 /// (See [SQLite doc](https://sqlite.org/c3ref/vtab_cursor.html))
-pub trait VTabCursor: Sized {
+pub unsafe trait VTabCursor: Sized {
     /// Begin a search of a virtual table.
     /// (See [SQLite doc](https://sqlite.org/vtab.html#the_xfilter_method))
     fn filter(&mut self, idx_num: c_int, idx_str: Option<&str>, args: &Values<'_>) -> Result<()>;

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -49,7 +49,7 @@ struct SeriesTab {
     base: ffi::sqlite3_vtab,
 }
 
-impl VTab for SeriesTab {
+unsafe impl VTab for SeriesTab {
     type Aux = ();
     type Cursor = SeriesTabCursor;
 
@@ -181,7 +181,7 @@ impl SeriesTabCursor {
         SeriesTabCursor::default()
     }
 }
-impl VTabCursor for SeriesTabCursor {
+unsafe impl VTabCursor for SeriesTabCursor {
     fn filter(&mut self, idx_num: c_int, _idx_str: Option<&str>, args: &Values<'_>) -> Result<()> {
         let idx_num = QueryPlanFlags::from_bits_truncate(idx_num);
         let mut i = 0;

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -9,19 +9,15 @@ use std::os::raw::c_int;
 use crate::ffi;
 use crate::types::Type;
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp, IndexInfo, Module, VTab, VTabConnection,
-    VTabCursor, Values,
+    eponymous_only_module, Context, IndexConstraintOp, IndexInfo, VTab, VTabConnection, VTabCursor,
+    Values,
 };
 use crate::{Connection, Result};
 
 /// `feature = "series"` Register the "generate_series" module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("generate_series", &SERIES_MODULE, aux)
-}
-
-lazy_static::lazy_static! {
-    static ref SERIES_MODULE: Module<SeriesTab> = eponymous_only_module::<SeriesTab>(1);
+    conn.create_module("generate_series", eponymous_only_module::<SeriesTab>(), aux)
 }
 
 // Column numbers

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -11,7 +11,7 @@ fn test_dummy_module() {
     use rusqlite::{version_number, Connection, Result};
     use std::os::raw::c_int;
 
-    let module = eponymous_only_module::<DummyTab>(1);
+    let module = eponymous_only_module::<DummyTab>();
 
     #[repr(C)]
     struct DummyTab {
@@ -19,7 +19,7 @@ fn test_dummy_module() {
         base: sqlite3_vtab,
     }
 
-    impl VTab for DummyTab {
+    unsafe impl VTab for DummyTab {
         type Aux = ();
         type Cursor = DummyTabCursor;
 
@@ -53,7 +53,7 @@ fn test_dummy_module() {
         row_id: i64,
     }
 
-    impl VTabCursor for DummyTabCursor {
+    unsafe impl VTabCursor for DummyTabCursor {
         fn filter(
             &mut self,
             _idx_num: c_int,


### PR DESCRIPTION
We should always be able to get static lifetimes for these. I've modified the existing functions (read_only_module, eponymous_only_module) so that they return &'static modules. If this is a problem in the future we could always `Box::leak(Box::new(the_mod))`, but I doubt it will be.

This now means we no longer need lazy_static to get static module references, although someone who wants to do that for some reason still can (it would look a little different).

I also removed the version numbers. The version number is of the structure's layout -- e.g. how many fields it has.

Allowing users to pass in a version number could allow specifying a version with more fields than it should have, and having sqlite call a function that doesn't exist.

Module is always either V2 or V3 in the code here, so we just pass in V2 since we don't use xShadowName.

Fixes #703. 