### PR TITLE
Avoid relying on sqlite to justify str::from_utf8_unchecked

### DIFF
--- a/src/collation.rs
+++ b/src/collation.rs
@@ -53,20 +53,18 @@ impl InnerConnection {
         where
             C: Fn(&str, &str) -> Ordering,
         {
-            use std::str;
-
             let r = catch_unwind(|| {
                 let boxed_f: *mut C = arg1 as *mut C;
                 assert!(!boxed_f.is_null(), "Internal error - null function pointer");
                 let s1 = {
                     let c_slice = slice::from_raw_parts(arg3 as *const u8, arg2 as usize);
-                    str::from_utf8_unchecked(c_slice)
+                    String::from_utf8_lossy(c_slice)
                 };
                 let s2 = {
                     let c_slice = slice::from_raw_parts(arg5 as *const u8, arg4 as usize);
-                    str::from_utf8_unchecked(c_slice)
+                    String::from_utf8_lossy(c_slice)
                 };
-                (*boxed_f)(s1, s2)
+                (*boxed_f)(s1.as_ref(), s2.as_ref())
             });
             let t = match r {
                 Err(_) => {
@@ -122,7 +120,7 @@ impl InnerConnection {
                 let conn = Connection::from_handle(arg2).unwrap();
                 let collation_name = {
                     let c_slice = CStr::from_ptr(arg3).to_bytes();
-                    str::from_utf8_unchecked(c_slice)
+                    str::from_utf8(c_slice).expect("illegal coallation sequence name")
                 };
                 callback(&conn, collation_name)
             });

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -188,16 +188,21 @@ impl InnerConnection {
             let action = Action::from(action_code);
             let db_name = {
                 let c_slice = CStr::from_ptr(db_str).to_bytes();
-                str::from_utf8_unchecked(c_slice)
+                str::from_utf8(c_slice)
             };
             let tbl_name = {
                 let c_slice = CStr::from_ptr(tbl_str).to_bytes();
-                str::from_utf8_unchecked(c_slice)
+                str::from_utf8(c_slice)
             };
 
             let _ = catch_unwind(|| {
                 let boxed_hook: *mut F = p_arg as *mut F;
-                (*boxed_hook)(action, db_name, tbl_name, row_id);
+                (*boxed_hook)(
+                    action,
+                    db_name.expect("illegal db name"),
+                    tbl_name.expect("illegal table name"),
+                    row_id,
+                );
             });
         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -69,9 +69,11 @@ impl Session<'_> {
             let boxed_filter: *mut F = p_arg as *mut F;
             let tbl_name = {
                 let c_slice = CStr::from_ptr(tbl_str).to_bytes();
-                str::from_utf8_unchecked(c_slice)
+                str::from_utf8(c_slice)
             };
-            if let Ok(true) = catch_unwind(|| (*boxed_filter)(tbl_name)) {
+            if let Ok(true) =
+                catch_unwind(|| (*boxed_filter)(tbl_name.expect("non-utf8 table name")))
+            {
                 1
             } else {
                 0
@@ -660,11 +662,11 @@ where
     let tuple: *mut (Option<F>, C) = p_ctx as *mut (Option<F>, C);
     let tbl_name = {
         let c_slice = CStr::from_ptr(tbl_str).to_bytes();
-        str::from_utf8_unchecked(c_slice)
+        str::from_utf8(c_slice)
     };
     match *tuple {
         (Some(ref filter), _) => {
-            if let Ok(true) = catch_unwind(|| filter(tbl_name)) {
+            if let Ok(true) = catch_unwind(|| filter(tbl_name.expect("illegal table name"))) {
                 1
             } else {
                 0

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -672,7 +672,7 @@ impl Statement<'_> {
         unsafe {
             match self.stmt.expanded_sql() {
                 Some(s) => {
-                    let sql = str::from_utf8_unchecked(s.to_bytes()).to_owned();
+                    let sql = String::from_utf8_lossy(s.to_bytes()).to_string();
                     ffi::sqlite3_free(s.as_ptr() as *mut _);
                     Some(sql)
                 }


### PR DESCRIPTION
> SQLite is not particular about the text it receives and is more than happy to process text strings that are not normalized or even well-formed UTF-8 or UTF-16. Thus, programmers who want to store IS08859 data can do so using the UTF-8 interfaces. As long as no attempts are made to use a UTF-16 collating sequence or SQL function, the byte sequence of the text will not be modified in any way.

In practice this can also happen from database corruption.